### PR TITLE
feat(auth): implement refresh token route and token renewal logic

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,0 +1,13 @@
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    SECRET_KEY: str
+    ALGORITHM: str = "HS256"
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    REFRESH_TOKEN_EXPIRE_DAYS: int = 7
+
+    class Config:
+        env_file = "/home/lamka/Desktop/MyProjects/Projects/Personalizo.al/backend/.env"
+
+settings = Settings()
+print("✅ ENV LOADED:", settings.SECRET_KEY)

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -8,6 +8,7 @@ from fastapi.security import OAuth2PasswordBearer
 from sqlalchemy.orm import Session
 from app.models.user import User
 from app.db import get_db
+from app.core.config import settings
 
 # 🔐 Load environment variables from .env
 load_dotenv()
@@ -71,3 +72,21 @@ def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(
         raise credentials_exception
 
     return user
+
+
+#REFRESH TOKEN 
+# Set token expirations
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+REFRESH_TOKEN_EXPIRE_DAYS = 7
+
+def create_access_token(data: dict, expires_delta: timedelta = None):
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES))
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+
+def create_refresh_token(data: dict):
+    to_encode = data.copy()
+    expire = datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    to_encode.update({"exp": expire})
+    return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -1,28 +1,24 @@
 from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
 from app.db import SessionLocal
 from app.models.user import User
 from app.schemas.auth import UserCreate, UserResponse, LoginRequest, TokenResponse
-from app.core.security import hash_password, verify_password, create_access_token, get_current_user  
-from app.schemas.auth import LoginRequest, TokenResponse
+from app.core.security import (
+    hash_password, verify_password, create_access_token,
+    create_refresh_token, get_current_user
+)
 from datetime import timedelta
 import os
-from dotenv import load_dotenv
-from fastapi.security import OAuth2PasswordBearer
-from app.core.security import get_current_user
-from fastapi.security import OAuth2PasswordRequestForm
+from jose import jwt, JWTError
+from app.core.config import settings
+from pydantic import BaseModel
 
 
+router = APIRouter(prefix="/auth", tags=["auth"])
 
-load_dotenv()
 
-
-router = APIRouter(
-    prefix="/auth",
-    tags=["auth"]
-)
-
-# Dependency: get database session
+# 🧠 Reusable DB dependency
 def get_db():
     db = SessionLocal()
     try:
@@ -30,72 +26,93 @@ def get_db():
     finally:
         db.close()
 
+# ✅ Register route
 @router.post("/register", response_model=UserResponse)
 def register(user_data: UserCreate, db: Session = Depends(get_db)):
-    # Check if user with same email or username already exists
     existing_user = db.query(User).filter(
         (User.email == user_data.email) | (User.username == user_data.username)
     ).first()
-
     if existing_user:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Email or username already taken."
-        )
+        raise HTTPException(status_code=400, detail="Email or username already taken")
 
-    # Create new user object with hashed password
     new_user = User(
         email=user_data.email,
         username=user_data.username,
         hashed_password=hash_password(user_data.password),
-        is_admin=user_data.is_admin
+        is_admin=user_data.is_admin,
     )
 
     db.add(new_user)
     db.commit()
     db.refresh(new_user)
-
     return new_user
 
-#LOGIN ROUTE
+
+# ✅ JSON login route (from frontend)
 @router.post("/login", response_model=TokenResponse)
 def login_user(login_data: LoginRequest, db: Session = Depends(get_db)):
-    # 🔍 Step 1: Look up the user
     user = db.query(User).filter(User.email == login_data.email).first()
-    if not user:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid email or password"
-        )
+    if not user or not verify_password(login_data.password, user.hashed_password):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
 
-    # 🔐 Step 2: Check password
-    if not verify_password(login_data.password, user.hashed_password):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid email or password"
-        )
+    access_token = create_access_token(data={"sub": user.email})
+    refresh_token = create_refresh_token(data={"sub": user.email})
 
-    # 🧾 Step 3: Create token
-    token_expiry = timedelta(minutes=int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", 30)))
-    token = create_access_token(data={"sub": user.email}, expires_delta=token_expiry)
-
-    # ✅ Step 4: Return token
-    return {"access_token": token, "token_type": "bearer"}
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "bearer"
+    }
 
 
-# Is User Logged in Route
-
-
-@router.get("/me", response_model=UserResponse)
-def read_users_me(current_user: User = Depends(get_current_user)):
-    return current_user
-
-
+# ✅ OAuth2 token route for Swagger UI login
 @router.post("/token", response_model=TokenResponse)
 def login_token(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(get_db)):
     user = db.query(User).filter(User.email == form_data.username).first()
     if not user or not verify_password(form_data.password, user.hashed_password):
         raise HTTPException(status_code=401, detail="Invalid credentials")
 
-    token = create_access_token(data={"sub": user.email})
-    return {"access_token": token, "token_type": "bearer"}
+    access_token = create_access_token(data={"sub": user.email})
+    refresh_token = create_refresh_token(data={"sub": user.email})
+
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "bearer"
+    }
+
+
+# ✅ Authenticated user info route
+@router.get("/me", response_model=UserResponse)
+def read_users_me(current_user: User = Depends(get_current_user)):
+    return current_user
+
+
+
+class RefreshTokenRequest(BaseModel):
+    refresh_token: str
+
+@router.post("/refresh", response_model=TokenResponse)
+def refresh_token(data: RefreshTokenRequest, db: Session = Depends(get_db)):
+    try:
+        payload = jwt.decode(data.refresh_token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        email: str = payload.get("sub")
+        if not email:
+            raise HTTPException(status_code=401, detail="Invalid refresh token")
+    except JWTError:
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+    user = db.query(User).filter(User.email == email).first()
+    if not user:
+        raise HTTPException(status_code=401, detail="User not found")
+
+    new_access_token = create_access_token(data={"sub": user.email})
+    new_refresh_token = create_refresh_token(data={"sub": user.email})
+
+    return {
+        "access_token": new_access_token,
+        "refresh_token": new_refresh_token,
+        "token_type": "bearer"
+    }
+
+

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -21,7 +21,6 @@ class UserResponse(BaseModel):
         "from_attributes": True  # ✅ Replaces orm_mode in Pydantic v2
     }
 
-from pydantic import BaseModel, EmailStr
 
 # 🧾 Schema for the login request (what the user sends)
 class LoginRequest(BaseModel):
@@ -29,7 +28,7 @@ class LoginRequest(BaseModel):
     password: str           # Plaintext password they enter
 
 
-# 🔐 Schema for the login response (what we send back)
 class TokenResponse(BaseModel):
-    access_token: str       # JWT access token
-    token_type: str         # Usually "bearer"
+    access_token: str
+    refresh_token: str
+    token_type: str = "bearer"


### PR DESCRIPTION
This PR implements secure refresh token functionality.

Added /auth/refresh route to issue new access and refresh tokens

Switched refresh token input to JSON body for cleaner API design

Updated config to pull token settings from .env

Fully tested with curl: login, token refresh, and protected routes work as expected

