### PR TITLE
Add db fixture for backend tests

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from app.db import engine
 from app.models import user  # ✅ Registers model
-from app.models.user import Base
+from app.db import Base
 from app.routes import auth
 from app.routes import admin
 from fastapi.openapi.utils import get_openapi

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,13 +1,6 @@
 # Importing base tools from SQLAlchemy
-from sqlalchemy import Column, Integer, String, DateTime, func
-from sqlalchemy.orm import declarative_base
-from sqlalchemy import Column, Integer, String, Boolean, DateTime
-from sqlalchemy.orm import declarative_base
-import datetime
-
-
-# This creates the base class that all models will inherit from
-Base = declarative_base()
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, func
+from app.db import Base
 
 # This defines our User table in the database
 class User(Base):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,21 +4,33 @@ import sqlalchemy
 from sqlalchemy.orm import sessionmaker
 import pytest
 
+
 @pytest.fixture
-def client(tmp_path):
+def db(tmp_path):
     os.environ.setdefault("SECRET_KEY", "testsecret")
     os.environ.setdefault("ALGORITHM", "HS256")
 
     from app import db as db_module
     db_file = tmp_path / "test.db"
-    engine = sqlalchemy.create_engine(f"sqlite:///{db_file}", connect_args={"check_same_thread": False})
+    engine = sqlalchemy.create_engine(
+        f"sqlite:///{db_file}", connect_args={"check_same_thread": False}
+    )
     TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
     db_module.engine = engine
     db_module.SessionLocal = TestingSessionLocal
 
-    from app.models.user import Base
+    from app.db import Base
     Base.metadata.create_all(bind=engine)
 
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture
+def client(db):
     import app.main as main_module
     importlib.reload(main_module)
 


### PR DESCRIPTION
## Summary
- unify `Base` import across app
- provide new `db` fixture in tests using temporary engine
- reload FastAPI app using that fixture
- update admin test to commit users directly with the db session

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6884ede36680832d9756fc5c4407950f