### PR TITLE
Fix env config path

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -7,7 +7,6 @@ class Settings(BaseSettings):
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7
 
     class Config:
-        env_file = "/home/lamka/Desktop/MyProjects/Projects/Personalizo.al/backend/.env"
+        env_file = ".env"
 
 settings = Settings()
-print("✅ ENV LOADED:", settings.SECRET_KEY)


### PR DESCRIPTION
## Summary
- update env_file path in `Settings` configuration
- drop noisy env loading print

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6884edb9d140832d8c12b2a960c35a3e