### PR TITLE
Use centralized SQLAlchemy Base

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,6 @@
 from fastapi import FastAPI
-from app.db import engine
+from app.db import engine, Base
 from app.models import user  # ✅ Registers model
-from app.models.user import Base
 from app.routes import auth
 from app.routes import admin
 from fastapi.openapi.utils import get_openapi

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,13 +1,8 @@
-# Importing base tools from SQLAlchemy
-from sqlalchemy import Column, Integer, String, DateTime, func
-from sqlalchemy.orm import declarative_base
-from sqlalchemy import Column, Integer, String, Boolean, DateTime
-from sqlalchemy.orm import declarative_base
-import datetime
+# Import SQLAlchemy helpers
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, func
 
-
-# This creates the base class that all models will inherit from
-Base = declarative_base()
+# Use the shared Base defined in app.db
+from app.db import Base
 
 # This defines our User table in the database
 class User(Base):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -16,7 +16,7 @@ def client(tmp_path):
     db_module.engine = engine
     db_module.SessionLocal = TestingSessionLocal
 
-    from app.models.user import Base
+    from app.db import Base
     Base.metadata.create_all(bind=engine)
 
     import app.main as main_module


### PR DESCRIPTION
## Summary
- reuse the Base from `app.db` across the project
- update references to this Base in the app and tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6884ec924178832d9fa84f6926c21141