### PR TITLE
Add backend requirements and update testing docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Personalizo.al
+
+This repository contains the backend and frontend of the Personalizo.al project.
+
+## Running backend tests
+
+Install the Python dependencies first:
+
+```bash
+pip install -r requirements.txt
+```
+
+After installing the dependencies, run the tests with:
+
+```bash
+pytest
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+sqlalchemy
+python-dotenv
+passlib[bcrypt]
+python-jose
+pydantic-settings
+pytest


### PR DESCRIPTION
## Summary
- add `requirements.txt` listing backend dependencies
- document installing requirements and running pytest

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6884f18b1404832da3984eb68bb18f32