### PR TITLE
Fix auth dependency import

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -1,6 +1,6 @@
 from fastapi import Depends, HTTPException, status
 from app.models.user import User
-from app.routes.auth import get_current_user  # Adjust if located elsewhere
+from app.core.security import get_current_user
 
 def is_admin(current_user: User = Depends(get_current_user)) -> User:
     if not current_user.is_admin:


### PR DESCRIPTION
## Summary
- fix dependency to import `get_current_user` from `app.core.security`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6884f18c2008832daa4077a5e3024a18