### PR TITLE
Update tests path for pytest

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,6 +3,12 @@ import importlib
 import sqlalchemy
 from sqlalchemy.orm import sessionmaker
 import pytest
+import sys
+from pathlib import Path
+
+# Ensure the backend directory is on sys.path so that "import app" works even
+# when tests are invoked from the repository root.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- allow importing `app` when running tests from repository root by updating `sys.path`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6884f18da908832db9807198679f190a