### PR TITLE
Fix App test to match rendered text

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('shows welcome text', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  expect(screen.getByText(/Jari App is ready/i)).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update frontend test to check for 'Jari App is ready'

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test` in `frontend` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884f18e80c0832d9eb66f65aebb0876