### PR TITLE
feat(song-package): add model, schema, routes, and seeding logic

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,8 @@ from app.models import user  # ✅ Registers model
 from app.routes import auth
 from app.routes import admin
 from fastapi.openapi.utils import get_openapi
+from app.routes import song_package  # 👈 import it
+
 
 # ✅ Create app first
 app = FastAPI()
@@ -11,9 +13,13 @@ app = FastAPI()
 # ✅ Create tables
 Base.metadata.create_all(bind=engine)
 
-# ✅ Include routers
+# ✅ Auth routers
 app.include_router(auth.router)
 app.include_router(admin.router)
+
+# ✅ Song routers
+app.include_router(song_package.router)  # 👈 song package route
+
 
 # ✅ Root route
 @app.get("/")

--- a/backend/app/models/song_package.py
+++ b/backend/app/models/song_package.py
@@ -1,0 +1,13 @@
+from sqlalchemy import Column, Integer, String, Boolean
+from app.db import Base
+
+class SongPackage(Base):
+    __tablename__ = "song_packages"
+
+    id = Column(Integer, primary_key=True, index=True)
+    tier = Column(String, unique=True, index=True)  # short_personal, full_personal, full_commercial
+    name = Column(String, nullable=False)
+    description = Column(String, nullable=True)
+    price_eur = Column(Integer, nullable=False)
+    duration_seconds = Column(Integer, nullable=False)
+    commercial_use = Column(Boolean, default=False)

--- a/backend/app/routes/song_package.py
+++ b/backend/app/routes/song_package.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.db import get_db
+from app.models.song_package import SongPackage
+from app.schemas.song_package import SongPackageResponse, SongPackageBase
+
+router = APIRouter(prefix="/packages", tags=["Song Packages"])
+
+@router.get("/", response_model=List[SongPackageResponse])
+def get_song_packages(db: Session = Depends(get_db)):
+    return db.query(SongPackage).all()
+
+@router.post("/", response_model=SongPackageResponse)
+def create_song_package(
+    payload: SongPackageBase,
+    db: Session = Depends(get_db)
+):
+    existing = db.query(SongPackage).filter(SongPackage.tier == payload.tier).first()
+    if existing:
+        raise HTTPException(status_code=400, detail="Tier already exists.")
+
+    new_package = SongPackage(**payload.dict())
+    db.add(new_package)
+    db.commit()
+    db.refresh(new_package)
+    return new_package

--- a/backend/app/schemas/song_package.py
+++ b/backend/app/schemas/song_package.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class SongPackageBase(BaseModel):
+    tier: str
+    name: str
+    description: Optional[str]
+    price_eur: int
+    duration_seconds: int
+    commercial_use: bool
+
+class SongPackageResponse(SongPackageBase):
+    id: int
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
### ✨ Summary

This PR introduces the `SongPackage` system, which defines productized song tiers (short, full, business) for the user-facing ordering flow.

### ✅ What's Included
- SQLAlchemy model: `SongPackage`
- Pydantic schemas: request/response DTOs
- FastAPI routes:
  - `GET /packages/`: list all song tiers
  - `POST /packages/`: create a new song tier (admin-only later)
- Seeding logic to auto-populate base tiers:
  - `short_personal`
  - `full_personal`
  - `full_commercial`

### 🎯 Purpose

This allows users to choose a predefined tier when placing an order. Logic like price, duration, and license type is now centralized and structured — critical for order creation and future payment processing.

### 🛠️ Next Steps

- Build `Order` model linked to `SongPackage`
- Allow users to submit song requests via form
- Connect payments and delivery flow
