### PR TITLE
feat(order): add order model, schema, and user-linked routes

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ from app.routes import auth
 from app.routes import admin
 from fastapi.openapi.utils import get_openapi
 from app.routes import song_package  # 👈 import it
+from app.routes import order
 
 
 # ✅ Create app first
@@ -19,6 +20,10 @@ app.include_router(admin.router)
 
 # ✅ Song routers
 app.include_router(song_package.router)  # 👈 song package route
+
+# ✅ Order Routers
+app.include_router(order.router)
+
 
 
 # ✅ Root route

--- a/backend/app/models/order.py
+++ b/backend/app/models/order.py
@@ -1,0 +1,28 @@
+from sqlalchemy import Column, Integer, String, ForeignKey, Enum, Text
+from sqlalchemy.orm import relationship
+from app.db import Base
+import enum
+
+class OrderStatus(str, enum.Enum):
+    pending = "pending"
+    in_progress = "in_progress"
+    delivered = "delivered"
+    cancelled = "cancelled"
+
+class Order(Base):
+    __tablename__ = "orders"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    song_package_id = Column(Integer, ForeignKey("song_packages.id"), nullable=False)
+
+    recipient_name = Column(String, nullable=False)
+    mood = Column(String, nullable=False)
+    facts = Column(Text, nullable=True)
+
+    status = Column(Enum(OrderStatus), default=OrderStatus.pending)
+    delivered_url = Column(String, nullable=True)
+
+    # relationships
+    user = relationship("User", back_populates="orders")
+    song_package = relationship("SongPackage")

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -25,3 +25,7 @@ class User(Base):
 
     # Check if user is admin - default is false
     is_admin = Column(Boolean, default=False)
+
+    #check order
+    orders = relationship("Order", back_populates="user")
+

--- a/backend/app/routes/order.py
+++ b/backend/app/routes/order.py
@@ -1,0 +1,41 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+
+from app.models.order import Order, OrderStatus
+from app.models.song_package import SongPackage
+from app.schemas.order import OrderCreate, OrderResponse
+from app.db import get_db
+from app.dependencies import get_current_user
+from app.models.user import User
+
+router = APIRouter(prefix="/orders", tags=["Orders"])
+
+@router.post("/", response_model=OrderResponse)
+def create_order(
+    payload: OrderCreate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    package = db.query(SongPackage).filter(SongPackage.id == payload.song_package_id).first()
+    if not package:
+        raise HTTPException(404, detail="Song package not found")
+
+    order = Order(
+        user_id=current_user.id,
+        song_package_id=payload.song_package_id,
+        recipient_name=payload.recipient_name,
+        mood=payload.mood,
+        facts=payload.facts,
+    )
+    db.add(order)
+    db.commit()
+    db.refresh(order)
+    return order
+
+@router.get("/me", response_model=List[OrderResponse])
+def get_my_orders(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    return db.query(Order).filter(Order.user_id == current_user.id).all()

--- a/backend/app/schemas/order.py
+++ b/backend/app/schemas/order.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel
+from typing import Optional
+from enum import Enum
+
+class OrderStatus(str, Enum):
+    pending = "pending"
+    in_progress = "in_progress"
+    delivered = "delivered"
+    cancelled = "cancelled"
+
+class OrderBase(BaseModel):
+    song_package_id: int
+    recipient_name: str
+    mood: str
+    facts: Optional[str]
+
+class OrderCreate(OrderBase):
+    pass
+
+class OrderResponse(OrderBase):
+    id: int
+    status: OrderStatus
+    delivered_url: Optional[str]
+
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
### ✨ Summary

Introduces the `Order` system to allow authenticated users to place custom song requests based on a selected `SongPackage`. Orders are linked to users and can be tracked by status.

---

### ✅ What's Included

- SQLAlchemy model: `Order`
  - Linked to `User` and `SongPackage`
  - Fields: recipient name, mood, facts, status, delivered URL
- Enum: `OrderStatus` (pending, in_progress, delivered, cancelled)
- Pydantic schemas: `OrderCreate`, `OrderResponse`
- Routes:
  - `POST /orders/`: Create new order (auth required)
  - `GET /orders/me`: Fetch current user's orders

---

### 🔐 Auth & Ownership

- Orders require authentication (`Depends(get_current_user)`)
- Only authenticated users can create and view their own orders

---

### 🧱 Data Relationships

- `Order.user_id` → `User.id`
- `Order.song_package_id` → `SongPackage.id`

---

### 🛠️ Next Steps

- Add admin/manual delivery (upload `delivered_url`)
- Add payment model (optional at launch)
- Connect to frontend form (React)
