### PR TITLE
bug(order): correct import path for get_current_user

### DIFF
--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,4 +1,6 @@
 from sqlalchemy import Column, Integer, String, Boolean, DateTime, func
+from sqlalchemy.orm import relationship
+
 
 # Use the shared Base defined in app.db
 

--- a/backend/app/routes/order.py
+++ b/backend/app/routes/order.py
@@ -6,8 +6,9 @@ from app.models.order import Order, OrderStatus
 from app.models.song_package import SongPackage
 from app.schemas.order import OrderCreate, OrderResponse
 from app.db import get_db
-from app.dependencies import get_current_user
 from app.models.user import User
+from app.core.security import get_current_user
+
 
 router = APIRouter(prefix="/orders", tags=["Orders"])
 


### PR DESCRIPTION
### 🐛 Bugfix Summary

This PR fixes a critical import error that was preventing the FastAPI server from starting.

### What was wrong?

- The `get_current_user` dependency was incorrectly imported from `app.dependencies`.
- The correct import path is `app.core.security`.

### Changes made

- Updated the import statement in `app/routes/order.py` to:
  ```python
  from app.core.security import get_current_user
