### PR TITLE
Unify schema config style

### DIFF
--- a/backend/app/schemas/song.py
+++ b/backend/app/schemas/song.py
@@ -18,6 +18,6 @@ class SongCreate(SongBase):
 class SongResponse(SongBase):
     id: int
     created_at: datetime
-
-    class Config:
-        from_attributes = True
+    model_config = {
+        "from_attributes": True
+    }

--- a/backend/app/schemas/song_package.py
+++ b/backend/app/schemas/song_package.py
@@ -11,6 +11,6 @@ class SongPackageBase(BaseModel):
 
 class SongPackageResponse(SongPackageBase):
     id: int
-
-    class Config:
-        orm_mode = True
+    model_config = {
+        "from_attributes": True
+    }


### PR DESCRIPTION
## Summary
- use `model_config` in song and song_package schemas
- drop old Config classes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -q -r backend/requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68863ca79da8832d8f67a2668133b885