### PR TITLE
Refactor test helpers

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,21 +1,7 @@
 import uuid
 from fastapi import status
 
-def register_user(client, email=None, username=None, password="password", is_admin=False):
-    email = email or f"{uuid.uuid4()}@example.com"
-    username = username or f"user_{uuid.uuid4().hex[:8]}"
-    response = client.post(
-        "/auth/register",
-        json={"email": email, "username": username, "password": password, "is_admin": is_admin},
-    )
-    assert response.status_code == status.HTTP_200_OK
-    return response.json()
-
-
-def login_user(client, email, password="password"):
-    response = client.post("/auth/login", json={"email": email, "password": password})
-    assert response.status_code == status.HTTP_200_OK
-    return response.json()
+from .utils import register_user, login_user
 
 
 def test_auth_flow(client):

--- a/backend/tests/test_order.py
+++ b/backend/tests/test_order.py
@@ -1,42 +1,6 @@
-import uuid
 from fastapi import status
 
-
-def register_user(client, email=None, username=None, password="password", is_admin=False):
-    email = email or f"{uuid.uuid4()}@example.com"
-    username = username or f"user_{uuid.uuid4().hex[:8]}"
-    response = client.post(
-        "/auth/register",
-        json={"email": email, "username": username, "password": password, "is_admin": is_admin},
-    )
-    assert response.status_code == status.HTTP_200_OK
-    return response.json()
-
-
-def login_user(client, email, password="password"):
-    response = client.post("/auth/login", json={"email": email, "password": password})
-    assert response.status_code == status.HTTP_200_OK
-    return response.json()
-
-
-def create_package(client, tier="basic"):
-    payload = {
-        "tier": tier,
-        "name": f"{tier}_package",
-        "description": "desc",
-        "price_eur": 10,
-        "duration_seconds": 30,
-        "commercial_use": False,
-    }
-    res = client.post("/packages/", json=payload)
-    assert res.status_code == status.HTTP_200_OK
-    return res.json()
-
-
-def auth_header(client):
-    user = register_user(client)
-    tokens = login_user(client, user["email"])
-    return {"Authorization": f"Bearer {tokens['access_token']}"}
+from .utils import register_user, login_user, create_package, auth_header
 
 
 def test_create_and_list_orders(client):

--- a/backend/tests/test_song.py
+++ b/backend/tests/test_song.py
@@ -1,57 +1,16 @@
-import uuid
 from fastapi import status
 
-# Helpers duplicated from other tests
-
-def register_user(client, email=None, username=None, password="password", is_admin=False):
-    email = email or f"{uuid.uuid4()}@example.com"
-    username = username or f"user_{uuid.uuid4().hex[:8]}"
-    response = client.post(
-        "/auth/register",
-        json={"email": email, "username": username, "password": password, "is_admin": is_admin},
-    )
-    assert response.status_code == status.HTTP_200_OK
-    return response.json()
 
 
-def login_user(client, email, password="password"):
-    response = client.post("/auth/login", json={"email": email, "password": password})
-    assert response.status_code == status.HTTP_200_OK
-    return response.json()
+from .utils import (
+    register_user,
+    login_user,
+    create_package,
+    auth_header,
+    create_order,
+)
 
 
-def create_package(client, tier="basic"):
-    payload = {
-        "tier": tier,
-        "name": f"{tier}_package",
-        "description": "desc",
-        "price_eur": 10,
-        "duration_seconds": 30,
-        "commercial_use": False,
-    }
-    res = client.post("/packages/", json=payload)
-    assert res.status_code == status.HTTP_200_OK
-    return res.json()
-
-
-def auth_header(client):
-    user = register_user(client)
-    tokens = login_user(client, user["email"])
-    return {"Authorization": f"Bearer {tokens['access_token']}"}
-
-
-def create_order(client):
-    package = create_package(client, "tier-song")
-    header = auth_header(client)
-    payload = {
-        "song_package_id": package["id"],
-        "recipient_name": "SongUser",
-        "mood": "happy",
-        "facts": "likes singing",
-    }
-    res = client.post("/orders/", json=payload, headers=header)
-    assert res.status_code == status.HTTP_200_OK
-    return res.json()
 
 
 def test_create_and_get_song(client):

--- a/backend/tests/utils.py
+++ b/backend/tests/utils.py
@@ -1,0 +1,59 @@
+import uuid
+from fastapi import status
+
+
+def register_user(client, email=None, username=None, password="password", is_admin=False):
+    """Register a user and return the response JSON."""
+    email = email or f"{uuid.uuid4()}@example.com"
+    username = username or f"user_{uuid.uuid4().hex[:8]}"
+    response = client.post(
+        "/auth/register",
+        json={"email": email, "username": username, "password": password, "is_admin": is_admin},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    return response.json()
+
+
+def login_user(client, email, password="password"):
+    """Login a user and return the token response JSON."""
+    response = client.post("/auth/login", json={"email": email, "password": password})
+    assert response.status_code == status.HTTP_200_OK
+    return response.json()
+
+
+def create_package(client, tier="basic"):
+    """Create a song package and return the response JSON."""
+    payload = {
+        "tier": tier,
+        "name": f"{tier}_package",
+        "description": "desc",
+        "price_eur": 10,
+        "duration_seconds": 30,
+        "commercial_use": False,
+    }
+    res = client.post("/packages/", json=payload)
+    assert res.status_code == status.HTTP_200_OK
+    return res.json()
+
+
+def auth_header(client):
+    """Return an Authorization header for a newly registered user."""
+    user = register_user(client)
+    tokens = login_user(client, user["email"])
+    return {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+def create_order(client):
+    """Create an order using a newly registered user and package."""
+    package = create_package(client, "tier-order")
+    header = auth_header(client)
+    payload = {
+        "song_package_id": package["id"],
+        "recipient_name": "SongUser",
+        "mood": "happy",
+        "facts": "likes singing",
+    }
+    res = client.post("/orders/", json=payload, headers=header)
+    assert res.status_code == status.HTTP_200_OK
+    return res.json()
+


### PR DESCRIPTION
## Summary
- add shared test helper utilities
- refactor auth, order and song tests to use the new helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68863d5fd400832d88cc745d8a1b5d44