### PR TITLE
Fix pytest helper imports

### DIFF
--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,1 @@
+# Marker file to treat the tests directory as a package for relative imports.


### PR DESCRIPTION
## Summary
- add an empty `__init__.py` to backend test suite so that relative imports work

## Testing
- `pytest backend/tests -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_688640de87d8832db10bee769e000d86