### PR TITLE
Fix warnings by using timezone-aware datetimes

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,4 +1,4 @@
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
     SECRET_KEY: str
@@ -6,7 +6,6 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7
 
-    class Config:
-        env_file = ".env"
+    model_config = SettingsConfigDict(env_file=".env")
 
 settings = Settings()

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from jose import JWTError, jwt
 from passlib.context import CryptContext
 from dotenv import load_dotenv
@@ -33,7 +33,7 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
 # 🧾 Create a JWT token
 def create_access_token(data: dict, expires_delta: timedelta = None) -> str:
     to_encode = data.copy()
-    expire = datetime.utcnow() + (
+    expire = datetime.now(timezone.utc) + (
         expires_delta or timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
     )
     to_encode.update({"exp": expire})
@@ -83,7 +83,7 @@ def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(
 # Refresh token utilities
 def create_refresh_token(data: dict) -> str:
     to_encode = data.copy()
-    expire = datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    expire = datetime.now(timezone.utc) + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
     to_encode.update({"exp": expire})
     return jwt.encode(
         to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM

--- a/backend/app/models/song.py
+++ b/backend/app/models/song.py
@@ -1,6 +1,6 @@
-from sqlalchemy import Column, Integer, String, ForeignKey, DateTime
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, func
 from sqlalchemy.orm import relationship
-from datetime import datetime
+from datetime import datetime, timezone
 from app.db import Base
 
 
@@ -14,6 +14,8 @@ class Song(Base):
     duration_seconds = Column(Integer, nullable=True)
     file_path = Column(String, nullable=False)
 
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
 
     order = relationship("Order", back_populates="song")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -5,10 +5,14 @@ from sqlalchemy.orm import sessionmaker
 import pytest
 import sys
 from pathlib import Path
+import warnings
 
 # Ensure the backend directory is on sys.path so that "import app" works even
 # when tests are invoked from the repository root.
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Silence deprecation warnings from third-party libraries
+warnings.filterwarnings("ignore", category=DeprecationWarning, module="passlib")
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- eliminate usage of `datetime.utcnow()` to avoid Python deprecation warnings
- update config to Pydantic v2 style
- suppress passlib deprecation warnings in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68864747b50c832d9634589b18dca871