### PR TITLE
Add missing backend tests

### DIFF
--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -48,3 +48,34 @@ def test_admin_access(client, db):
 
     res_user = client.get("/admin/users", headers=user_header)
     assert res_user.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_register_duplicate(client):
+    email = f"{uuid.uuid4()}@example.com"
+    username = f"user_{uuid.uuid4().hex[:8]}"
+
+    first = client.post(
+        "/auth/register",
+        json={"email": email, "username": username, "password": "pass"},
+    )
+    assert first.status_code == status.HTTP_200_OK
+
+    duplicate = client.post(
+        "/auth/register",
+        json={"email": email, "username": username, "password": "pass"},
+    )
+    assert duplicate.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_login_invalid_credentials(client):
+    user = register_user(client)
+
+    res = client.post(
+        "/auth/login", json={"email": user["email"], "password": "wrong"}
+    )
+    assert res.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+def test_refresh_invalid_token(client):
+    res = client.post("/auth/refresh", json={"refresh_token": "bad"})
+    assert res.status_code == status.HTTP_401_UNAUTHORIZED

--- a/backend/tests/test_song.py
+++ b/backend/tests/test_song.py
@@ -61,3 +61,45 @@ def test_duplicate_song_for_order(client):
 
     res2 = client.post("/songs/", json=song_payload)
     assert res2.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_get_song_not_found(client):
+    res = client.get("/songs/9999")
+    assert res.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_get_my_songs(client):
+    user = register_user(client)
+    tokens = login_user(client, user["email"])
+    header = {"Authorization": f"Bearer {tokens['access_token']}"}
+
+    package = create_package(client, "mytier")
+    order_payload = {
+        "song_package_id": package["id"],
+        "recipient_name": "Me",
+        "mood": "joy",
+        "facts": None,
+    }
+    order_res = client.post("/orders/", json=order_payload, headers=header)
+    assert order_res.status_code == status.HTTP_200_OK
+    order = order_res.json()
+
+    song_payload = {
+        "order_id": order["id"],
+        "title": "Mine",
+        "genre": "rock",
+        "duration_seconds": 30,
+        "file_path": "mine.mp3",
+    }
+    client.post("/songs/", json=song_payload)
+
+    res = client.get("/songs/me", headers=header)
+    assert res.status_code == status.HTTP_200_OK
+    songs = res.json()
+    assert len(songs) == 1
+    assert songs[0]["title"] == "Mine"
+
+
+def test_get_my_songs_requires_auth(client):
+    res = client.get("/songs/me")
+    assert res.status_code == status.HTTP_401_UNAUTHORIZED


### PR DESCRIPTION
## Summary
- add negative auth tests for duplicate registration, invalid login, and refresh
- extend song tests for not found cases and /songs/me

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68865cbdca1c832da2d21d89f0688e84