### PR TITLE
Fix model imports

### DIFF
--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,0 +1,21 @@
+
+"""Convenience exports for model classes.
+
+This module exposes the individual SQLAlchemy models so that other
+parts of the application can simply import ``app.models`` and access
+``User``, ``Order`` and the rest directly.  The tests for the admin
+routes rely on this behaviour when they call ``db.query(models.Order)``.
+"""
+
+from .user import User
+from .order import Order, OrderStatus
+from .song import Song
+from .song_package import SongPackage
+
+__all__ = [
+    "User",
+    "Order",
+    "OrderStatus",
+    "Song",
+    "SongPackage",
+]


### PR DESCRIPTION
## Summary
- expose SQLAlchemy models in `app.models.__init__` so admin routes work

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68867103d5e8832db493413215fb8a1c