### PR TITLE
Fix admin orders package field

### DIFF
--- a/backend/app/routes/admin_orders.py
+++ b/backend/app/routes/admin_orders.py
@@ -36,7 +36,7 @@ def get_all_orders(
             delivered_url=o.delivered_url,
             created_at=o.created_at,
             user={"id": o.user.id, "email": o.user.email},
-            package={"id": o.package.id, "title": o.package.title},
+            package={"id": o.song_package.id, "title": o.song_package.title},
         )
         for o in orders
     ]


### PR DESCRIPTION
## Summary
- update admin orders list comprehension to use `song_package`
- maintain output dict key as `package`

## Testing
- `pytest backend/tests/test_admin_orders.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_688672a5dc74832d9fb08ab61cacbfab