### PR TITLE
Rename PackagePreview title field

### DIFF
--- a/backend/app/routes/admin_orders.py
+++ b/backend/app/routes/admin_orders.py
@@ -36,7 +36,7 @@ def get_all_orders(
             delivered_url=o.delivered_url,
             created_at=o.created_at,
             user={"id": o.user.id, "email": o.user.email},
-            package={"id": o.song_package.id, "title": o.song_package.title},
+            package={"id": o.song_package.id, "name": o.song_package.name},
         )
         for o in orders
     ]

--- a/backend/app/schemas/order.py
+++ b/backend/app/schemas/order.py
@@ -38,7 +38,7 @@ class UserPreview(BaseModel):
 
 class PackagePreview(BaseModel):
     id: int
-    title: str
+    name: str
 
 # ---------- Admin Order Out ----------
 class AdminOrderOut(BaseModel):


### PR DESCRIPTION
## Summary
- rename `PackagePreview.title` to `name`
- update admin orders route to use `name` when returning packages

## Testing
- `pytest -v` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_688674580b84832d8f7012ad490bed3d