### PR TITLE
Fix tests by adjusting media mount

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -52,7 +52,8 @@ app.include_router(admin_songs.router)
 
 
 # Serve uploaded song files from /media/
-app.mount("/media", StaticFiles(directory="media"), name="media")
+# Allow the directory to be missing during startup (tests may create it later)
+app.mount("/media", StaticFiles(directory="media", check_dir=False), name="media")
 
 
 


### PR DESCRIPTION
## Summary
- allow missing media directory when mounting StaticFiles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68868ac726f0832d915208ddd630d49c