### PR TITLE
Add profile management endpoints

### DIFF
--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -32,3 +32,10 @@ class TokenResponse(BaseModel):
     access_token: str
     refresh_token: str
     token_type: str = "bearer"
+
+
+# Data for updating the authenticated user
+class UserUpdate(BaseModel):
+    email: Optional[EmailStr] = None
+    username: Optional[str] = None
+    password: Optional[str] = None


### PR DESCRIPTION
## Summary
- create `UserUpdate` schema for optional user fields
- implement update, password change, and delete endpoints
- test profile updates, password changes, and account deletion

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6887acc008c0832da11c31fa442db17c