### PR TITLE
Set delivered_url on song upload

### DIFF
--- a/backend/app/routes/admin_songs.py
+++ b/backend/app/routes/admin_songs.py
@@ -66,8 +66,9 @@ async def upload_song(
         )
         db.add(song)
 
-        # 7. Mark order as delivered
+        # 7. Mark order as delivered and store url
         order.status = "delivered"
+        order.delivered_url = f"/media/songs/{filename}"
 
         db.commit()
         db.refresh(song)

--- a/backend/tests/test_admin_songs.py
+++ b/backend/tests/test_admin_songs.py
@@ -41,7 +41,9 @@ def test_upload_song_success(client):
 
     orders = client.get("/admin/orders/", headers=header)
     assert orders.status_code == status.HTTP_200_OK
-    assert orders.json()[0]["status"] == "delivered"
+    admin_order = orders.json()[0]
+    assert admin_order["status"] == "delivered"
+    assert admin_order["delivered_url"].startswith("/media/songs/")
 
 
 def test_upload_song_invalid_file_type(client):


### PR DESCRIPTION
## Summary
- when admins upload a song mark the order as delivered with delivered_url
- test that admin order response includes delivered_url after upload

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6887b017c06c832dad0951441882f48d