### PR TITLE
Add order update and cancel routes

### DIFF
--- a/backend/app/routes/order.py
+++ b/backend/app/routes/order.py
@@ -4,7 +4,7 @@ from typing import List
 
 from app.models.order import Order, OrderStatus
 from app.models.song_package import SongPackage
-from app.schemas.order import OrderCreate, OrderResponse
+from app.schemas.order import OrderCreate, OrderResponse, OrderUpdate, OrderCancel
 from app.db import get_db
 from app.models.user import User
 from app.core.security import get_current_user
@@ -40,3 +40,48 @@ def get_my_orders(
     current_user: User = Depends(get_current_user),
 ):
     return db.query(Order).filter(Order.user_id == current_user.id).all()
+
+
+@router.patch("/{order_id}", response_model=OrderResponse)
+def update_order(
+    order_id: int,
+    payload: OrderUpdate,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    order = db.query(Order).filter(Order.id == order_id).first()
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+    if order.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized to update this order")
+    if order.status != OrderStatus.pending:
+        raise HTTPException(status_code=400, detail="Only pending orders can be updated")
+
+    for field, value in payload.model_dump(exclude_unset=True).items():
+        setattr(order, field, value)
+    db.commit()
+    db.refresh(order)
+    return order
+
+
+@router.post("/{order_id}/cancel", response_model=OrderResponse)
+def cancel_order(
+    order_id: int,
+    payload: OrderCancel | None = None,
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user),
+):
+    order = db.query(Order).filter(Order.id == order_id).first()
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+    if order.user_id != current_user.id:
+        raise HTTPException(status_code=403, detail="Not authorized to cancel this order")
+    if order.status == OrderStatus.delivered:
+        raise HTTPException(status_code=400, detail="Delivered orders cannot be cancelled")
+    if order.status == OrderStatus.cancelled:
+        raise HTTPException(status_code=400, detail="Order already cancelled")
+
+    order.status = OrderStatus.cancelled
+    db.commit()
+    db.refresh(order)
+    return order

--- a/backend/app/schemas/order.py
+++ b/backend/app/schemas/order.py
@@ -21,6 +21,17 @@ class OrderBase(BaseModel):
 class OrderCreate(OrderBase):
     pass
 
+# ---------- Order Update ----------
+class OrderUpdate(BaseModel):
+    recipient_name: str | None = None
+    mood: str | None = None
+    facts: str | None = None
+
+
+# ---------- Order Cancel ----------
+class OrderCancel(BaseModel):
+    reason: str | None = None
+
 # ---------- Order Response ----------
 class OrderResponse(OrderBase):
     id: int

--- a/backend/tests/test_order.py
+++ b/backend/tests/test_order.py
@@ -1,6 +1,18 @@
 from fastapi import status
 
-from .utils import register_user, login_user, create_package, auth_header
+import os
+import io
+from .utils import register_user, login_user, create_package, auth_header, create_order
+
+
+def admin_header(client):
+    admin = register_user(client, is_admin=True)
+    tokens = login_user(client, admin["email"])
+    return {"Authorization": f"Bearer {tokens['access_token']}"}
+
+
+def ensure_media_dir():
+    os.makedirs(os.path.join("media", "songs"), exist_ok=True)
 
 
 def test_create_and_list_orders(client):
@@ -47,3 +59,49 @@ def test_create_order_invalid_package(client):
     }
     res = client.post("/orders/", json=payload, headers=header)
     assert res.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_update_order(client):
+    order = create_order(client)
+    header = auth_header(client)
+    update_payload = {"mood": "excited", "facts": "new facts"}
+    res = client.patch(f"/orders/{order['id']}", json=update_payload, headers=header)
+    assert res.status_code == status.HTTP_200_OK
+    updated = res.json()
+    assert updated["mood"] == "excited"
+    assert updated["facts"] == "new facts"
+
+
+def test_update_order_not_owner(client):
+    order = create_order(client)
+    user = register_user(client)
+    tokens = login_user(client, user["email"])
+    other_header = {"Authorization": f"Bearer {tokens['access_token']}"}
+    res = client.patch(f"/orders/{order['id']}", json={"mood": "angry"}, headers=other_header)
+    assert res.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_cancel_order(client):
+    order = create_order(client)
+    header = auth_header(client)
+    res = client.post(f"/orders/{order['id']}/cancel", headers=header)
+    assert res.status_code == status.HTTP_200_OK
+    assert res.json()["status"] == "cancelled"
+
+
+def test_cancel_order_delivered(client):
+    ensure_media_dir()
+    order = create_order(client)
+    header_admin = admin_header(client)
+    data = {
+        "order_id": order["id"],
+        "title": "delivered",
+        "genre": "pop",
+        "duration_seconds": 1,
+    }
+    files = {"file": ("song.mp3", io.BytesIO(b"abc"), "audio/mp3")}
+    client.post("/admin/songs/", data=data, files=files, headers=header_admin)
+
+    user_header = auth_header(client)
+    res = client.post(f"/orders/{order['id']}/cancel", headers=user_header)
+    assert res.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
## Summary
- allow updating own orders via PATCH `/orders/{order_id}`
- allow cancelling an order with `/orders/{order_id}/cancel`
- define `OrderUpdate` and `OrderCancel` schemas
- extend order tests for update and cancel scenarios

## Testing
- `pytest -q` *(fails: Could not install fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6887b27f33ec832da0ff4000378b5a32