### PR TITLE
Add SMTP email sending for auth tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,17 @@ npm test
 ```
 
 Both commands should execute the respective test suites (`pytest` for Python and `npm test` for React).
+
+## Email Configuration
+
+Account verification and password reset emails are sent using SMTP. Configure the
+following environment variables (e.g. in a `.env` file) for real email delivery:
+
+- `SMTP_HOST` – SMTP server hostname
+- `SMTP_PORT` – SMTP server port (default `587`)
+- `SMTP_USER` – username for SMTP authentication
+- `SMTP_PASSWORD` – password for SMTP authentication
+- `EMAIL_FROM` – address used as the "from" field
+
+If `SMTP_HOST` is not set, emails are printed to the console instead. This
+allows tests to run without an email server.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -6,6 +6,12 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7
 
+    SMTP_HOST: str | None = None
+    SMTP_PORT: int = 587
+    SMTP_USER: str | None = None
+    SMTP_PASSWORD: str | None = None
+    EMAIL_FROM: str = "no-reply@example.com"
+
     model_config = SettingsConfigDict(env_file=".env")
 
 settings = Settings()

--- a/backend/app/core/email.py
+++ b/backend/app/core/email.py
@@ -1,0 +1,33 @@
+import smtplib
+from email.message import EmailMessage
+
+from app.core.config import settings
+
+
+def send_email(to: str, subject: str, body: str) -> None:
+    """Send an email using SMTP.
+
+    If SMTP_HOST is not configured, the message is printed to stdout instead of
+    being sent. This allows tests to run without a mail server configured.
+    """
+    host = settings.SMTP_HOST
+    port = settings.SMTP_PORT
+    user = settings.SMTP_USER
+    password = settings.SMTP_PASSWORD
+    from_addr = settings.EMAIL_FROM
+
+    msg = EmailMessage()
+    msg["Subject"] = subject
+    msg["From"] = from_addr
+    msg["To"] = to
+    msg.set_content(body)
+
+    if not host:
+        print(f"Email (mock) to {to}: {subject}\n{body}")
+        return
+
+    with smtplib.SMTP(host, port) as server:
+        server.starttls()
+        if user and password:
+            server.login(user, password)
+        server.send_message(msg)

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -25,6 +25,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from jose import jwt, JWTError
 from app.core.config import settings
+from app.core.email import send_email
 from pydantic import BaseModel
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -200,6 +201,12 @@ def request_verification(
         raise HTTPException(status_code=404, detail="User not found")
     user.verification_token = str(uuid.uuid4())
     db.commit()
+    verify_url = f"https://example.com/verify?token={user.verification_token}"
+    send_email(
+        to=user.email,
+        subject="Verify your account",
+        body=f"Click the link to verify your account: {verify_url}",
+    )
     return {"token": user.verification_token}
 
 
@@ -232,6 +239,12 @@ def password_reset_request(
     user.reset_token = str(uuid.uuid4())
     user.reset_token_expires = datetime.now(timezone.utc) + timedelta(hours=1)
     db.commit()
+    reset_url = f"https://example.com/reset?token={user.reset_token}"
+    send_email(
+        to=user.email,
+        subject="Password reset",
+        body=f"Reset your password using this link: {reset_url}",
+    )
     return {"token": user.reset_token}
 
 


### PR DESCRIPTION
## Summary
- send email from auth routes when verification or password reset are requested
- add configurable SMTP settings
- document email setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6887c15bd40c832d8e4277de53735327