### PR TITLE
Add register + verify flow in frontend

### DIFF
--- a/frontend/src/pages/Register/Register.tsx
+++ b/frontend/src/pages/Register/Register.tsx
@@ -1,8 +1,86 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Container } from './styles'
+import Button from '../../components/Button'
+import {
+  register,
+  requestVerification,
+  verifyAccount,
+} from '../../services/authService'
 
 const Register = () => {
-  return <Container>Register Page</Container>
-}
+  const [email, setEmail] = useState('')
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [token, setToken] = useState('')
+  const [registered, setRegistered] = useState(false)
+  const [verified, setVerified] = useState(false)
+  const [message, setMessage] = useState('')
 
+  const handleRegister = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      await register(email, username, password)
+      const res = await requestVerification(email)
+      setRegistered(true)
+      setMessage(`Verification token: ${res.token}`)
+    } catch (err) {
+      setMessage('Registration failed')
+    }
+  }
+
+  const handleVerify = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      await verifyAccount(token)
+      setVerified(true)
+      setMessage('Account verified!')
+    } catch (err) {
+      setMessage('Verification failed')
+    }
+  }
+
+  return (
+    <Container>
+      {!registered && (
+        <form onSubmit={handleRegister}>
+          <div>
+            <input
+              placeholder="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </div>
+          <div>
+            <input
+              placeholder="Username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+            />
+          </div>
+          <div>
+            <input
+              type="password"
+              placeholder="Password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </div>
+          <Button label="Register" />
+        </form>
+      )}
+      {registered && !verified && (
+        <form onSubmit={handleVerify}>
+          <p>{message}</p>
+          <input
+            placeholder="Verification token"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+          />
+          <Button label="Verify" />
+        </form>
+      )}
+      {verified && <p>{message}</p>}
+    </Container>
+  )
+}
 export default Register

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -4,3 +4,26 @@ export const login = async (email: string, password: string) => {
   const response = await api.post('/auth/login', { email, password })
   return response.data
 }
+
+export const register = async (
+  email: string,
+  username: string,
+  password: string
+) => {
+  const response = await api.post('/auth/register', {
+    email,
+    username,
+    password,
+  })
+  return response.data
+}
+
+export const requestVerification = async (email: string) => {
+  const response = await api.post('/auth/request-verify', { email })
+  return response.data
+}
+
+export const verifyAccount = async (token: string) => {
+  const response = await api.post('/auth/verify', { token })
+  return response.data
+}


### PR DESCRIPTION
## Summary
- implement register page logic with email verification
- expose register and verification endpoints in auth service

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `npm test --silent` *(fails: react-scripts not found)*
- `npx tsc --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6888f38abb24832db38fa184cd913896