### PR TITLE
Implement frontend login

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -4,15 +4,18 @@ import App from './App'
 import { BrowserRouter } from 'react-router-dom'
 import { ThemeProvider } from 'styled-components'
 import { lightTheme, darkTheme } from './theme'
+import { AuthProvider } from './store/authContext'
 
 const Root = () => {
   const [isDarkMode, setIsDarkMode] = useState(true)
 
   return (
     <BrowserRouter>
-      <ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>
-        <App />
-      </ThemeProvider>
+      <AuthProvider>
+        <ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>
+          <App />
+        </ThemeProvider>
+      </AuthProvider>
     </BrowserRouter>
   )
 }

--- a/frontend/src/pages/Login/Login.tsx
+++ b/frontend/src/pages/Login/Login.tsx
@@ -1,8 +1,53 @@
-import React from 'react'
+import React, { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { Container } from './styles'
+import Button from '../../components/Button'
+import { login } from '../../services/authService'
+import { saveToken } from '../../utils/token'
+import { useAuthContext } from '../../store/authContext'
 
 const Login = () => {
-  return <Container>Login Page</Container>
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [message, setMessage] = useState('')
+  const navigate = useNavigate()
+  const { setIsAuthenticated } = useAuthContext()
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      const data = await login(email, password)
+      saveToken(data.access_token)
+      setIsAuthenticated(true)
+      navigate('/')
+    } catch (err) {
+      setMessage('Login failed')
+    }
+  }
+
+  return (
+    <Container>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <input
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </div>
+        <div>
+          <input
+            type="password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        <Button label="Login" />
+      </form>
+      {message && <p>{message}</p>}
+    </Container>
+  )
 }
 
 export default Login

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,7 +1,16 @@
 import axios from 'axios'
+import { getToken } from '../utils/token'
 
 const api = axios.create({
   baseURL: 'http://localhost:8000',
+})
+
+api.interceptors.request.use((config) => {
+  const token = getToken()
+  if (token && config.headers) {
+    config.headers.Authorization = `Bearer ${token}`
+  }
+  return config
 })
 
 export default api


### PR DESCRIPTION
## Summary
- implement login form with authentication context
- persist tokens on API requests
- add AuthProvider wrapper around app

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888f77fe35c832d8eecdcf7ce1e3e3d