### PR TITLE
Add migration for user verification columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ source venv/bin/activate
 pip install -r backend/requirements.txt
 ```
 
+After installing the dependencies, apply the database migrations so that the
+SQLite schema is up to date:
+
+```bash
+cd backend
+alembic upgrade head
+```
+
 ### Node (frontend)
 
 Install Node packages using npm:

--- a/backend/alembic/versions/0ddc4b2e5115_add_user_verification_columns.py
+++ b/backend/alembic/versions/0ddc4b2e5115_add_user_verification_columns.py
@@ -1,0 +1,33 @@
+"""Add user verification columns
+
+Revision ID: 0ddc4b2e5115
+Revises: 9ba33b1ba50b
+Create Date: 2025-07-27 22:00:00
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '0ddc4b2e5115'
+down_revision: Union[str, Sequence[str], None] = '9ba33b1ba50b'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column('users', sa.Column('is_verified', sa.Boolean(), server_default='0'))
+    op.add_column('users', sa.Column('verification_token', sa.String(), nullable=True))
+    op.add_column('users', sa.Column('reset_token', sa.String(), nullable=True))
+    op.add_column('users', sa.Column('reset_token_expires', sa.DateTime(timezone=True), nullable=True))
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column('users', 'reset_token_expires')
+    op.drop_column('users', 'reset_token')
+    op.drop_column('users', 'verification_token')
+    op.drop_column('users', 'is_verified')


### PR DESCRIPTION
## Summary
- add Alembic migration for new user verification-related columns
- document running `alembic upgrade head` when setting up the backend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6888fd4cb6f4832db6d4bee7c6c11973