### PR TITLE
Fix auth form centering on mobile

### DIFF
--- a/frontend/src/styles/authFormStyles.ts
+++ b/frontend/src/styles/authFormStyles.ts
@@ -4,7 +4,8 @@ export const AuthContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 100vh; /* <- USE height not min-height here for full centering */
+  height: 100%; /* allow layout to control full screen height */
+  min-height: 100vh; /* fill the viewport on mobile */
   padding: 1rem;
   background-color: ${({ theme }) => theme.background};
 `


### PR DESCRIPTION
## Summary
- update `AuthContainer` to stretch with the layout and set a minimum viewport height

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889124da648832db704d140c2011c6d