### PR TITLE
Fix auth page centering on mobile

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,8 @@
-html, body {
+html, body, #root {
   margin: 0;
   padding: 0;
+  height: 100%;
+  min-height: 100vh;
   width: 100%;
   max-width: 100vw;
   overflow-x: hidden;

--- a/frontend/src/layouts/styles.ts
+++ b/frontend/src/layouts/styles.ts
@@ -4,6 +4,7 @@ export const LayoutWrapper = styled.div`
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  height: 100%;
   width: 100%;
   max-width: 100vw;
   overflow-x: hidden;

--- a/frontend/src/pages/Login/styles.ts
+++ b/frontend/src/pages/Login/styles.ts
@@ -1,8 +1,12 @@
 import styled from 'styled-components'
 
 export const Container = styled.div`
-  max-width: 800px;
-  margin: 2rem auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  min-height: 100vh;
   padding: 1rem;
   font-size: 1.2rem;
   text-align: center;

--- a/frontend/src/pages/Register/styles.ts
+++ b/frontend/src/pages/Register/styles.ts
@@ -1,8 +1,12 @@
 import styled from 'styled-components'
 
 export const Container = styled.div`
-  max-width: 800px;
-  margin: 2rem auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  min-height: 100vh;
   padding: 1rem;
   font-size: 1.2rem;
   text-align: center;

--- a/frontend/src/styles/authFormStyles.ts
+++ b/frontend/src/styles/authFormStyles.ts
@@ -4,7 +4,8 @@ export const AuthContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 100vh; /* <- USE height not min-height here for full centering */
+  height: 100%; /* allow layout to control full screen height */
+  min-height: 100vh; /* fill the viewport on mobile */
   padding: 1rem;
   background-color: ${({ theme }) => theme.background};
 `


### PR DESCRIPTION
## Summary
- ensure html/body/root fill the viewport
- update layout wrapper to stretch full height
- add responsive centering styles to Login and Register pages

## Testing
- `pytest -q` *(fails: command not found)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889124da648832db704d140c2011c6d