### PR TITLE
Fix horizontal centering for login and register pages

### DIFF
--- a/frontend/src/styles/authFormStyles.ts
+++ b/frontend/src/styles/authFormStyles.ts
@@ -6,6 +6,7 @@ export const AuthContainer = styled.div`
   align-items: center;
   height: 100%; /* allow layout to control full screen height */
   min-height: 100vh; /* fill the viewport on mobile */
+  width: 100%;
   padding: 1rem;
   background-color: ${({ theme }) => theme.background};
 `


### PR DESCRIPTION
## Summary
- set 100% width for auth container

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6889163eb9a8832d8013119c495a07d4