### PR TITLE
Fix auth pages centering by loading global styles

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from 'react-router-dom'
 import { ThemeProvider } from 'styled-components'
 import { lightTheme, darkTheme } from './theme'
 import { AuthProvider } from './store/authContext'
+import './index.css'
 
 const Root = () => {
   const [isDarkMode, setIsDarkMode] = useState(true)


### PR DESCRIPTION
## Summary
- load global index.css in React entrypoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68891df69400832dbaa16a91107f4685