### PR TITLE
Add navigation header

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,10 +1,20 @@
 import React from 'react'
-import { Container, Title } from './styles'
+import { Container, Title, NavMenu, NavItem } from './styles'
 
 const Header = () => {
   return (
     <Container>
       <Title>Personalizo.al</Title>
+      <NavMenu>
+        <NavItem to="/" end>
+          Home
+        </NavItem>
+        <NavItem to="/packages">Packages</NavItem>
+        <NavItem to="/orders">Orders</NavItem>
+        <NavItem to="/profile">Profile</NavItem>
+        <NavItem to="/login">Login</NavItem>
+        <NavItem to="/register">Register</NavItem>
+      </NavMenu>
     </Container>
   )
 }

--- a/frontend/src/components/Header/styles.ts
+++ b/frontend/src/components/Header/styles.ts
@@ -1,11 +1,30 @@
 import styled from 'styled-components'
+import { NavLink } from 'react-router-dom'
 
 export const Container = styled.header`
   padding: 1rem;
   border-bottom: 1px solid #eee;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 `
 
 export const Title = styled.h1`
   font-size: 1.8rem;
   color: #222;
+  margin: 0;
+`
+
+export const NavMenu = styled.nav`
+  display: flex;
+  gap: 1rem;
+`
+
+export const NavItem = styled(NavLink)`
+  color: ${({ theme }) => theme.text};
+  text-decoration: none;
+
+  &.active {
+    border-bottom: 2px solid ${({ theme }) => theme.primary};
+  }
 `


### PR DESCRIPTION
## Summary
- add navigation links to the Header component
- style Header to arrange navigation menu

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a3377d9ec832d82f05b382e7d25e0