### PR TITLE
Add navigation header

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,10 +1,41 @@
 import React from 'react'
-import { Container, Title } from './styles'
+import { useNavigate } from 'react-router-dom'
+import { useAuthContext } from '../../store/authContext'
+import { clearToken } from '../../utils/token'
+import { Container, Title, NavMenu, NavItem, LogoutButton } from './styles'
 
 const Header = () => {
+  const navigate = useNavigate()
+  const { isAuthenticated, setIsAuthenticated } = useAuthContext()
+
+  const handleLogout = () => {
+    clearToken()
+    setIsAuthenticated(false)
+    navigate('/login')
+  }
+
   return (
     <Container>
       <Title>Personalizo.al</Title>
+      <NavMenu>
+        <NavItem to="/" end>
+          Home
+        </NavItem>
+        <NavItem to="/packages">Package</NavItem>
+        {isAuthenticated ? (
+          <>
+            <NavItem to="/orders">Orders</NavItem>
+            <NavItem to="/mysongs">My Songs</NavItem>
+            <LogoutButton onClick={handleLogout}>Logout</LogoutButton>
+          </>
+        ) : (
+          <>
+            <NavItem to="/about">About</NavItem>
+            <NavItem to="/register">Register</NavItem>
+            <NavItem to="/login">Login</NavItem>
+          </>
+        )}
+      </NavMenu>
     </Container>
   )
 }

--- a/frontend/src/components/Header/styles.ts
+++ b/frontend/src/components/Header/styles.ts
@@ -1,11 +1,37 @@
 import styled from 'styled-components'
+import { NavLink } from 'react-router-dom'
 
 export const Container = styled.header`
   padding: 1rem;
   border-bottom: 1px solid #eee;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 `
 
 export const Title = styled.h1`
   font-size: 1.8rem;
   color: #222;
+  margin: 0;
+`
+
+export const NavMenu = styled.nav`
+  display: flex;
+  gap: 1rem;
+`
+
+export const NavItem = styled(NavLink)`
+  color: ${({ theme }) => theme.text};
+  text-decoration: none;
+
+  &.active {
+    border-bottom: 2px solid ${({ theme }) => theme.primary};
+  }
+`
+
+export const LogoutButton = styled.button`
+  background: none;
+  border: none;
+  color: ${({ theme }) => theme.text};
+  cursor: pointer;
 `

--- a/frontend/src/pages/About/About.tsx
+++ b/frontend/src/pages/About/About.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Container } from './styles'
+
+const About = () => {
+  return <Container>About Page</Container>
+}
+
+export default About

--- a/frontend/src/pages/About/index.ts
+++ b/frontend/src/pages/About/index.ts
@@ -1,0 +1,1 @@
+export { default } from './About'

--- a/frontend/src/pages/About/styles.ts
+++ b/frontend/src/pages/About/styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+
+export const Container = styled.div`
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 1rem;
+  font-size: 1.2rem;
+  text-align: center;
+`

--- a/frontend/src/pages/MySongs/MySongs.tsx
+++ b/frontend/src/pages/MySongs/MySongs.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+import { Container } from './styles'
+
+const MySongs = () => {
+  return <Container>My Songs Page</Container>
+}
+
+export default MySongs

--- a/frontend/src/pages/MySongs/index.ts
+++ b/frontend/src/pages/MySongs/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MySongs'

--- a/frontend/src/pages/MySongs/styles.ts
+++ b/frontend/src/pages/MySongs/styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+
+export const Container = styled.div`
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 1rem;
+  font-size: 1.2rem;
+  text-align: center;
+`

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -6,6 +6,8 @@ import Register from '../pages/Register'
 import Orders from '../pages/Orders'
 import SongPackages from '../pages/SongPackages'
 import Profile from '../pages/Profile'
+import About from '../pages/About'
+import MySongs from '../pages/MySongs'
 
 const AppRoutes = () => {
   return (
@@ -16,6 +18,8 @@ const AppRoutes = () => {
       <Route path="/orders" element={<Orders />} />
       <Route path="/packages" element={<SongPackages />} />
       <Route path="/profile" element={<Profile />} />
+      <Route path="/about" element={<About />} />
+      <Route path="/mysongs" element={<MySongs />} />
     </Routes>
   )
 }


### PR DESCRIPTION
## Summary
- add navigation links to the Header component
- style Header to arrange navigation menu
- add About and MySongs pages
- use auth context for conditional menu items

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a3377d9ec832d82f05b382e7d25e0