### PR TITLE
Add song package retrieval route and tests

### DIFF
--- a/backend/app/routes/song_package.py
+++ b/backend/app/routes/song_package.py
@@ -16,6 +16,14 @@ router = APIRouter(prefix="/packages", tags=["Song Packages"])
 def get_song_packages(db: Session = Depends(get_db)):
     return db.query(SongPackage).all()
 
+
+@router.get("/{package_id}", response_model=SongPackageResponse)
+def get_package(package_id: int, db: Session = Depends(get_db)):
+    package = db.query(SongPackage).filter(SongPackage.id == package_id).first()
+    if not package:
+        raise HTTPException(status_code=404, detail="Song package not found")
+    return package
+
 @router.post("/", response_model=SongPackageResponse)
 def create_song_package(
     payload: SongPackageBase,

--- a/backend/tests/test_song_package.py
+++ b/backend/tests/test_song_package.py
@@ -63,3 +63,19 @@ def test_update_and_delete_package(client):
     res = client.get("/packages/")
     ids = [p["id"] for p in res.json()]
     assert pkg["id"] not in ids
+
+
+def test_get_package(client):
+    res = create_package(client, "get")
+    assert res.status_code == status.HTTP_200_OK
+    pkg = res.json()
+
+    res = client.get(f"/packages/{pkg['id']}")
+    assert res.status_code == status.HTTP_200_OK
+    data = res.json()
+    assert data["id"] == pkg["id"]
+
+
+def test_get_package_not_found(client):
+    res = client.get("/packages/9999")
+    assert res.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
## Summary
- implement GET `/packages/{package_id}` route
- test getting packages by id and 404 for missing packages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -q -r backend/requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688a448b24c0832daba295fe60e1a3aa