### PR TITLE
Add package detail fetching

### DIFF
--- a/backend/app/routes/song_package.py
+++ b/backend/app/routes/song_package.py
@@ -16,6 +16,14 @@ router = APIRouter(prefix="/packages", tags=["Song Packages"])
 def get_song_packages(db: Session = Depends(get_db)):
     return db.query(SongPackage).all()
 
+
+@router.get("/{package_id}", response_model=SongPackageResponse)
+def get_song_package(package_id: int, db: Session = Depends(get_db)):
+    package = db.query(SongPackage).filter(SongPackage.id == package_id).first()
+    if not package:
+        raise HTTPException(status_code=404, detail="Song package not found")
+    return package
+
 @router.post("/", response_model=SongPackageResponse)
 def create_song_package(
     payload: SongPackageBase,

--- a/backend/tests/test_song_package.py
+++ b/backend/tests/test_song_package.py
@@ -39,6 +39,18 @@ def test_song_package_flow(client):
     assert dup.status_code == status.HTTP_400_BAD_REQUEST
 
 
+def test_get_package_by_id(client):
+    res = create_package(client, "single")
+    assert res.status_code == status.HTTP_200_OK
+    pkg = res.json()
+
+    res = client.get(f"/packages/{pkg['id']}")
+    assert res.status_code == status.HTTP_200_OK
+    data = res.json()
+    assert data["id"] == pkg["id"]
+    assert data["tier"] == "single"
+
+
 def test_update_and_delete_package(client):
     res = create_package(client, "upd")
     assert res.status_code == status.HTTP_200_OK

--- a/frontend/src/pages/PackageDetail/PackageDetail.tsx
+++ b/frontend/src/pages/PackageDetail/PackageDetail.tsx
@@ -1,17 +1,26 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { getPackage } from '../../services/songPackageService'
+import { SongPackage } from '../../types/models'
 import { Overlay, Modal, ActionButton } from './styles'
-
-const packages = {
-  short: { name: 'Short & Sweet', desc: '30–45s song\n1 verse + hook' },
-  full: { name: 'Full Package', desc: '60–75s song\nCustom tone, extra detail' },
-  business: { name: 'Business Ad', desc: 'Commercial jingle\nCustom beat rights' },
-}
 
 const PackageDetail = () => {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
-  const pack = id ? packages[id as keyof typeof packages] : undefined
+  const [pack, setPack] = useState<SongPackage | null>(null)
+
+  useEffect(() => {
+    const fetchData = async () => {
+      if (!id) return
+      try {
+        const data = await getPackage(id)
+        setPack(data)
+      } catch {
+        setPack(null)
+      }
+    }
+    fetchData()
+  }, [id])
 
   if (!pack) {
     return null
@@ -21,7 +30,7 @@ const PackageDetail = () => {
     <Overlay>
       <Modal>
         <h2>{pack.name}</h2>
-        <p>{pack.desc}</p>
+        <p>{pack.description}</p>
         <ActionButton onClick={() => navigate(`/packages/${id}/create`)}>
           Customize Song
         </ActionButton>

--- a/frontend/src/services/songPackageService.ts
+++ b/frontend/src/services/songPackageService.ts
@@ -1,0 +1,8 @@
+import api from './api'
+import { SongPackage } from '../types/models'
+
+export const getPackage = async (id: number | string): Promise<SongPackage> => {
+  const response = await api.get(`/packages/${id}`)
+  return response.data
+}
+


### PR DESCRIPTION
## Summary
- support fetching song package by id in backend
- test package retrieval endpoint
- add songPackageService for frontend API access
- load package details from API in PackageDetail page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a448a0acc832db46cd41adf284ecd