### PR TITLE
Implement basic cart flow

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from 'react-router-dom'
 import { ThemeProvider } from 'styled-components'
 import { lightTheme, darkTheme } from './theme'
 import { AuthProvider } from './store/authContext'
+import { CartProvider } from './store/cartContext'
 import './index.css'
 
 const Root = () => {
@@ -13,9 +14,11 @@ const Root = () => {
   return (
     <BrowserRouter>
       <AuthProvider>
-        <ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>
-          <App />
-        </ThemeProvider>
+        <CartProvider>
+          <ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>
+            <App />
+          </ThemeProvider>
+        </CartProvider>
       </AuthProvider>
     </BrowserRouter>
   )

--- a/frontend/src/pages/Cart/Cart.tsx
+++ b/frontend/src/pages/Cart/Cart.tsx
@@ -1,8 +1,33 @@
 import React from 'react'
 import { Container } from './styles'
+import { useCartContext } from '../../store/cartContext'
 
 const Cart = () => {
-  return <Container>Cart Page</Container>
+  const { selectedPackage, order } = useCartContext()
+
+  if (!selectedPackage || !order) {
+    return <Container>Your cart is empty.</Container>
+  }
+
+  return (
+    <Container>
+      <h2>Order Summary</h2>
+      <p>
+        <strong>Package:</strong> {selectedPackage.name} (€{selectedPackage.price})
+      </p>
+      <p>
+        <strong>Recipient:</strong> {order.recipient_name}
+      </p>
+      <p>
+        <strong>Mood:</strong> {order.mood}
+      </p>
+      {order.facts && (
+        <p>
+          <strong>Facts:</strong> {order.facts}
+        </p>
+      )}
+    </Container>
+  )
 }
 
 export default Cart

--- a/frontend/src/pages/PackageDetail/PackageDetail.tsx
+++ b/frontend/src/pages/PackageDetail/PackageDetail.tsx
@@ -1,16 +1,18 @@
 import React from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import { Overlay, Modal, ActionButton } from './styles'
+import { useCartContext } from '../../store/cartContext'
 
 const packages = {
-  short: { name: 'Short & Sweet', desc: '30–45s song\n1 verse + hook' },
-  full: { name: 'Full Package', desc: '60–75s song\nCustom tone, extra detail' },
-  business: { name: 'Business Ad', desc: 'Commercial jingle\nCustom beat rights' },
+  short: { id: 1, name: 'Short & Sweet', price: 15, desc: '30–45s song\n1 verse + hook' },
+  full: { id: 2, name: 'Full Package', price: 29, desc: '60–75s song\nCustom tone, extra detail' },
+  business: { id: 3, name: 'Business Ad', price: 59, desc: 'Commercial jingle\nCustom beat rights' },
 }
 
 const PackageDetail = () => {
   const { id } = useParams<{ id: string }>()
   const navigate = useNavigate()
+  const { setSelectedPackage } = useCartContext()
   const pack = id ? packages[id as keyof typeof packages] : undefined
 
   if (!pack) {
@@ -22,7 +24,17 @@ const PackageDetail = () => {
       <Modal>
         <h2>{pack.name}</h2>
         <p>{pack.desc}</p>
-        <ActionButton onClick={() => navigate(`/packages/${id}/create`)}>
+        <ActionButton
+          onClick={() => {
+            setSelectedPackage({
+              id: pack.id,
+              name: pack.name,
+              price: pack.price,
+              description: pack.desc,
+            })
+            navigate(`/packages/${id}/create`)
+          }}
+        >
           Customize Song
         </ActionButton>
       </Modal>

--- a/frontend/src/pages/SongForm/SongForm.tsx
+++ b/frontend/src/pages/SongForm/SongForm.tsx
@@ -1,75 +1,56 @@
 import React, { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import {
-  Overlay,
-  Modal,
-  TabSwitcher,
-  TabButton,
-  Form,
-  Input,
-  TextArea,
-  ToggleRow,
-  SubmitButton,
-} from './styles'
+import { useCartContext } from '../../store/cartContext'
+import { createOrder } from '../../services/orderService'
+import { Overlay, Modal, Form, Input, TextArea, SubmitButton } from './styles'
 
 const SongForm = () => {
-  const [mode, setMode] = useState<'simple' | 'custom'>('simple')
-  const [instrumental, setInstrumental] = useState(false)
-  const [isPublic, setIsPublic] = useState(true)
+  const [recipient, setRecipient] = useState('')
+  const [mood, setMood] = useState('')
+  const [facts, setFacts] = useState('')
   const navigate = useNavigate()
+  const { selectedPackage, setOrder } = useCartContext()
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    navigate('/cart')
+    if (!selectedPackage) return
+    try {
+      const order = await createOrder({
+        song_package_id: selectedPackage.id,
+        recipient_name: recipient,
+        mood,
+        facts,
+      })
+      setOrder(order)
+      navigate('/cart')
+    } catch (err) {
+      console.error(err)
+    }
   }
 
   return (
     <Overlay>
       <Modal>
-        <TabSwitcher>
-          <TabButton
-            $active={mode === 'simple'}
-            onClick={() => setMode('simple')}
-          >
-            Simple
-          </TabButton>
-          <TabButton
-            $active={mode === 'custom'}
-            onClick={() => setMode('custom')}
-          >
-            Custom
-          </TabButton>
-        </TabSwitcher>
+        <h2>Create your song</h2>
         <Form onSubmit={handleSubmit}>
-          {mode === 'simple' ? (
-            <TextArea placeholder="Tell us about the person" required />
-          ) : (
-            <>
-              <Input placeholder="Song Title" required />
-              <Input placeholder="Genre" />
-              <Input placeholder="Mood" />
-              <TextArea placeholder="Lyrics or details" />
-            </>
-          )}
-          <ToggleRow>
-            <label>
-              <input
-                type="checkbox"
-                checked={instrumental}
-                onChange={() => setInstrumental(!instrumental)}
-              />{' '}
-              Instrumental Mode
-            </label>
-            <label>
-              <input
-                type="checkbox"
-                checked={isPublic}
-                onChange={() => setIsPublic(!isPublic)}
-              />{' '}
-              Display Public
-            </label>
-          </ToggleRow>
-          <SubmitButton type="submit">Generate Song</SubmitButton>
+          <Input
+            placeholder="Recipient Name"
+            value={recipient}
+            onChange={(e) => setRecipient(e.target.value)}
+            required
+          />
+          <Input
+            placeholder="Mood"
+            value={mood}
+            onChange={(e) => setMood(e.target.value)}
+            required
+          />
+          <TextArea
+            placeholder="Facts about them"
+            value={facts}
+            onChange={(e) => setFacts(e.target.value)}
+          />
+          <SubmitButton type="submit">Submit Order</SubmitButton>
         </Form>
       </Modal>
     </Overlay>

--- a/frontend/src/pages/SongPackages/SongPackages.tsx
+++ b/frontend/src/pages/SongPackages/SongPackages.tsx
@@ -1,33 +1,40 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Overlay, Modal, PackagesGrid, PackageCard } from './styles'
+import { Overlay, Modal, PackagesGrid, PackageCard, CustomizeButton } from './styles'
+import { useCartContext } from '../../store/cartContext'
+import { SongPackage } from '../../types/models'
 
-const packages = [
+const packages: Array<SongPackage & { slug: string }> = [
   {
-    id: 'short',
+    id: 1,
+    slug: 'short',
     name: 'Short & Sweet',
-    price: '€15',
+    price: 15,
     description: '30–45s song\n1 verse + hook',
   },
   {
-    id: 'full',
+    id: 2,
+    slug: 'full',
     name: 'Full Package',
-    price: '€29',
+    price: 29,
     description: '60–75s song\nCustom tone, extra detail',
   },
   {
-    id: 'business',
+    id: 3,
+    slug: 'business',
     name: 'Business Ad',
-    price: '€59–99',
+    price: 59,
     description: 'Commercial jingle\nCustom beat rights',
   },
 ]
 
 const SongPackages = () => {
   const navigate = useNavigate()
+  const { setSelectedPackage } = useCartContext()
 
-  const handleSelect = (id: string) => {
-    navigate(`/packages/${id}`)
+  const handleCustomize = (pack: (typeof packages)[0]) => {
+    setSelectedPackage({ id: pack.id, name: pack.name, price: pack.price, description: pack.description })
+    navigate(`/packages/${pack.slug}/create`)
   }
 
   return (
@@ -36,10 +43,13 @@ const SongPackages = () => {
         <h2>Select a Package</h2>
         <PackagesGrid>
           {packages.map((p) => (
-            <PackageCard key={p.id} onClick={() => handleSelect(p.id)}>
+            <PackageCard key={p.id}>
               <h3>{p.name}</h3>
-              <p>{p.price}</p>
+              <p>€{p.price}</p>
               <small>{p.description}</small>
+              <CustomizeButton onClick={() => handleCustomize(p)}>
+                Customize Song
+              </CustomizeButton>
             </PackageCard>
           ))}
         </PackagesGrid>

--- a/frontend/src/pages/SongPackages/styles.ts
+++ b/frontend/src/pages/SongPackages/styles.ts
@@ -52,3 +52,13 @@ export const PackageCard = styled.div`
     font-size: 0.8rem;
   }
 `
+
+export const CustomizeButton = styled.button`
+  margin-top: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border: none;
+  border-radius: 6px;
+  background: ${({ theme }) => theme.primary};
+  color: #fff;
+  cursor: pointer;
+`

--- a/frontend/src/services/orderService.ts
+++ b/frontend/src/services/orderService.ts
@@ -4,3 +4,15 @@ export const getOrders = async () => {
   const response = await api.get('/orders/me')
   return response.data
 }
+
+export interface CreateOrderPayload {
+  song_package_id: number
+  recipient_name: string
+  mood: string
+  facts?: string
+}
+
+export const createOrder = async (payload: CreateOrderPayload) => {
+  const response = await api.post('/orders/', payload)
+  return response.data
+}

--- a/frontend/src/store/cartContext.tsx
+++ b/frontend/src/store/cartContext.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext, useState } from 'react'
+import { SongPackage, Order } from '../types/models'
+
+type CartContextType = {
+  selectedPackage: SongPackage | null
+  setSelectedPackage: (p: SongPackage | null) => void
+  order: Order | null
+  setOrder: (o: Order | null) => void
+}
+
+const CartContext = createContext<CartContextType | undefined>(undefined)
+
+export const CartProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [selectedPackage, setSelectedPackage] = useState<SongPackage | null>(null)
+  const [order, setOrder] = useState<Order | null>(null)
+
+  return (
+    <CartContext.Provider value={{ selectedPackage, setSelectedPackage, order, setOrder }}>
+      {children}
+    </CartContext.Provider>
+  )
+}
+
+export const useCartContext = () => {
+  const context = useContext(CartContext)
+  if (!context) throw new Error('useCartContext must be used within CartProvider')
+  return context
+}

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -11,3 +11,13 @@ export interface SongPackage {
   price: number
   description: string
 }
+
+export interface Order {
+  id: number
+  song_package_id: number
+  recipient_name: string
+  mood: string
+  facts: string | null
+  status: string
+  delivered_url: string | null
+}


### PR DESCRIPTION
## Summary
- add `CartContext` with selected package and order
- submit order details in `SongForm` and post to backend
- store chosen package when selecting a song package
- show order summary in cart page

## Testing
- `npm test --silent -- -w=0 --runInBand` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a448c303c832dbeb6c8d351faa62b