### PR TITLE
Connect song creation flow to backend

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -5,6 +5,7 @@ import { BrowserRouter } from 'react-router-dom'
 import { ThemeProvider } from 'styled-components'
 import { lightTheme, darkTheme } from './theme'
 import { AuthProvider } from './store/authContext'
+import { CartProvider } from './store/cartContext'
 import './index.css'
 
 const Root = () => {
@@ -13,9 +14,11 @@ const Root = () => {
   return (
     <BrowserRouter>
       <AuthProvider>
-        <ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>
-          <App />
-        </ThemeProvider>
+        <CartProvider>
+          <ThemeProvider theme={isDarkMode ? darkTheme : lightTheme}>
+            <App />
+          </ThemeProvider>
+        </CartProvider>
       </AuthProvider>
     </BrowserRouter>
   )

--- a/frontend/src/pages/Cart/Cart.tsx
+++ b/frontend/src/pages/Cart/Cart.tsx
@@ -1,8 +1,23 @@
 import React from 'react'
 import { Container } from './styles'
+import { useCartContext } from '../../store/cartContext'
 
 const Cart = () => {
-  return <Container>Cart Page</Container>
-}
+  const { selectedPackage, order } = useCartContext()
 
+  if (!selectedPackage || !order) {
+    return <Container>No items in cart</Container>
+  }
+
+  return (
+    <Container>
+      <h2>Order Summary</h2>
+      <p>
+        Package: {selectedPackage.name} - €{selectedPackage.price}
+      </p>
+      <p>Recipient: {order.recipient_name}</p>
+      <p>Mood: {order.mood}</p>
+    </Container>
+  )
+}
 export default Cart

--- a/frontend/src/pages/SongForm/SongForm.tsx
+++ b/frontend/src/pages/SongForm/SongForm.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import React, { useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
 import {
   Overlay,
   Modal,
@@ -11,16 +11,56 @@ import {
   ToggleRow,
   SubmitButton,
 } from './styles'
+import { createOrder } from '../../services/orderService'
+import { getSongPackage } from '../../services/songPackageService'
+import { useCartContext } from '../../store/cartContext'
+import { SongPackage } from '../../types/models'
 
 const SongForm = () => {
   const [mode, setMode] = useState<'simple' | 'custom'>('simple')
   const [instrumental, setInstrumental] = useState(false)
   const [isPublic, setIsPublic] = useState(true)
+  const [recipient, setRecipient] = useState('')
+  const [mood, setMood] = useState('')
+  const [facts, setFacts] = useState('')
   const navigate = useNavigate()
+  const { id } = useParams<{ id: string }>()
+  const { setOrder, setPackage, selectedPackage } = useCartContext()
+  const [pack, setPack] = useState<SongPackage | null>(selectedPackage)
 
-  const handleSubmit = (e: React.FormEvent) => {
+  useEffect(() => {
+    const fetchPackage = async () => {
+      if (id && !pack) {
+        const data = await getSongPackage(Number(id))
+        const mapped: SongPackage = {
+          id: data.id,
+          name: data.name,
+          price: data.price_eur,
+          description: data.description,
+        }
+        setPack(mapped)
+        setPackage(mapped)
+      }
+    }
+    fetchPackage()
+  }, [id])
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    navigate('/cart')
+    if (!id) return
+    try {
+      const payload = {
+        song_package_id: Number(id),
+        recipient_name: recipient,
+        mood,
+        facts,
+      }
+      const data = await createOrder(payload)
+      setOrder(data)
+      navigate('/cart')
+    } catch (err) {
+      console.error('Failed to create order')
+    }
   }
 
   return (
@@ -41,14 +81,33 @@ const SongForm = () => {
           </TabButton>
         </TabSwitcher>
         <Form onSubmit={handleSubmit}>
+          <Input
+            placeholder="Recipient Name"
+            value={recipient}
+            onChange={(e) => setRecipient(e.target.value)}
+            required
+          />
+          <Input
+            placeholder="Mood"
+            value={mood}
+            onChange={(e) => setMood(e.target.value)}
+          />
           {mode === 'simple' ? (
-            <TextArea placeholder="Tell us about the person" required />
+            <TextArea
+              placeholder="Tell us about the person"
+              value={facts}
+              onChange={(e) => setFacts(e.target.value)}
+              required
+            />
           ) : (
             <>
               <Input placeholder="Song Title" required />
               <Input placeholder="Genre" />
-              <Input placeholder="Mood" />
-              <TextArea placeholder="Lyrics or details" />
+              <TextArea
+                placeholder="Lyrics or details"
+                value={facts}
+                onChange={(e) => setFacts(e.target.value)}
+              />
             </>
           )}
           <ToggleRow>

--- a/frontend/src/pages/SongPackages/SongPackages.tsx
+++ b/frontend/src/pages/SongPackages/SongPackages.tsx
@@ -3,12 +3,14 @@ import { useNavigate } from 'react-router-dom'
 import { Overlay, Modal, PackagesGrid, PackageCard } from './styles'
 import { getSongPackages } from '../../services/songPackageService'
 import { SongPackage } from '../../types/models'
+import { useCartContext } from '../../store/cartContext'
 
 const SongPackages = () => {
   const [packages, setPackages] = useState<SongPackage[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
   const navigate = useNavigate()
+  const { setPackage } = useCartContext()
 
   useEffect(() => {
     const fetchPackages = async () => {
@@ -31,6 +33,7 @@ const SongPackages = () => {
   }, [])
 
   const handleSelect = (id: number) => {
+    setPackage(null)
     navigate(`/packages/${id}`)
   }
 

--- a/frontend/src/services/orderService.ts
+++ b/frontend/src/services/orderService.ts
@@ -4,3 +4,15 @@ export const getOrders = async () => {
   const response = await api.get('/orders/me')
   return response.data
 }
+
+export interface CreateOrderPayload {
+  song_package_id: number
+  recipient_name: string
+  mood: string
+  facts?: string
+}
+
+export const createOrder = async (payload: CreateOrderPayload) => {
+  const response = await api.post('/orders/', payload)
+  return response.data
+}

--- a/frontend/src/services/songPackageService.ts
+++ b/frontend/src/services/songPackageService.ts
@@ -4,3 +4,8 @@ export const getSongPackages = async () => {
   const response = await api.get('/packages')
   return response.data
 }
+
+export const getSongPackage = async (id: number) => {
+  const response = await api.get(`/packages/${id}`)
+  return response.data
+}

--- a/frontend/src/store/cartContext.tsx
+++ b/frontend/src/store/cartContext.tsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext, useState } from 'react'
+import { SongPackage, Order } from '../types/models'
+
+interface CartContextType {
+  selectedPackage: SongPackage | null
+  order: Order | null
+  setPackage: (p: SongPackage | null) => void
+  setOrder: (o: Order | null) => void
+  clearCart: () => void
+}
+
+const CartContext = createContext<CartContextType | undefined>(undefined)
+
+export const CartProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [selectedPackage, setSelectedPackage] = useState<SongPackage | null>(null)
+  const [order, setOrder] = useState<Order | null>(null)
+
+  const clearCart = () => {
+    setSelectedPackage(null)
+    setOrder(null)
+  }
+
+  return (
+    <CartContext.Provider
+      value={{ selectedPackage, order, setPackage: setSelectedPackage, setOrder, clearCart }}
+    >
+      {children}
+    </CartContext.Provider>
+  )
+}
+
+export const useCartContext = () => {
+  const ctx = useContext(CartContext)
+  if (!ctx) throw new Error('useCartContext must be used within CartProvider')
+  return ctx
+}

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -11,3 +11,13 @@ export interface SongPackage {
   price: number
   description: string
 }
+
+export interface Order {
+  id: number
+  song_package_id: number
+  recipient_name: string
+  mood: string
+  facts?: string | null
+  status: string
+  delivered_url?: string | null
+}


### PR DESCRIPTION
## Summary
- add cart context to track selected package and created order
- fetch package data from backend for the detail view
- integrate song form with backend to create orders
- display order summary in the cart
- expose helper APIs for single package and order creation
- wrap app in the new CartProvider

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent -- --runTestsByPath src/App.test.tsx` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a488a5d6c832dadeba2cf0fb1d40d