### PR TITLE
Add order update and cancel API

### DIFF
--- a/frontend/src/pages/Orders/Orders.tsx
+++ b/frontend/src/pages/Orders/Orders.tsx
@@ -1,8 +1,77 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Container } from './styles'
+import { getOrders, cancelOrder } from '../../services/orderService'
+import { getSongPackages } from '../../services/songPackageService'
+import { Order, SongPackage } from '../../types/models'
 
 const Orders = () => {
-  return <Container>Orders Page</Container>
+  const [orders, setOrders] = useState<Order[]>([])
+  const [packages, setPackages] = useState<Record<number, SongPackage>>({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const orderData = await getOrders()
+        setOrders(orderData)
+        const pkgData = await getSongPackages()
+        const map: Record<number, SongPackage> = {}
+        pkgData.forEach((p: any) => {
+          map[p.id] = {
+            id: p.id,
+            name: p.name,
+            price: p.price_eur,
+            description: p.description,
+          }
+        })
+        setPackages(map)
+      } catch (err) {
+        setError('Failed to load orders')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [])
+
+  const handleCancel = async (id: number) => {
+    try {
+      const updated = await cancelOrder(id)
+      setOrders((prev) =>
+        prev.map((o) => (o.id === id ? { ...o, status: updated.status } : o)),
+      )
+    } catch (err) {
+      console.error('Failed to cancel order')
+    }
+  }
+
+  if (loading) return <Container>Loading...</Container>
+  if (error) return <Container>{error}</Container>
+
+  return (
+    <Container>
+      <h2>Your Orders</h2>
+      {orders.length === 0 ? (
+        <p>No orders found.</p>
+      ) : (
+        <ul>
+          {orders.map((o) => (
+            <li key={o.id} style={{ marginBottom: '1rem' }}>
+              <p>
+                Package:{' '}
+                {packages[o.song_package_id]?.name || o.song_package_id}
+              </p>
+              <p>Status: {o.status}</p>
+              {o.status === 'pending' && (
+                <button onClick={() => handleCancel(o.id)}>Cancel</button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </Container>
+  )
 }
 
 export default Orders

--- a/frontend/src/services/orderService.ts
+++ b/frontend/src/services/orderService.ts
@@ -16,3 +16,26 @@ export const createOrder = async (payload: CreateOrderPayload) => {
   const response = await api.post('/orders/', payload)
   return response.data
 }
+
+export interface UpdateOrderPayload {
+  recipient_name?: string
+  mood?: string
+  facts?: string
+}
+
+export const updateOrder = async (id: number, payload: UpdateOrderPayload) => {
+  const response = await api.patch(`/orders/${id}`, payload)
+  return response.data
+}
+
+export interface CancelOrderPayload {
+  reason?: string
+}
+
+export const cancelOrder = async (
+  id: number,
+  payload?: CancelOrderPayload,
+) => {
+  const response = await api.post(`/orders/${id}/cancel`, payload)
+  return response.data
+}


### PR DESCRIPTION
## Summary
- implement update/cancel functions in `orderService`
- fetch and display orders, with ability to cancel, in `Orders` page

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest -q` *(fails: could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688a4bef14f0832d8f6b8c905c82ca76