### PR TITLE
Add song service and update MySongs page

### DIFF
--- a/frontend/src/pages/MySongs/MySongs.tsx
+++ b/frontend/src/pages/MySongs/MySongs.tsx
@@ -1,8 +1,64 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Container } from './styles'
+import { getMySongs } from '../../services/songService'
+import { getOrders } from '../../services/orderService'
+import { Song, Order } from '../../types/models'
 
 const MySongs = () => {
-  return <Container>My Songs Page</Container>
+  const [songs, setSongs] = useState<Song[]>([])
+  const [orders, setOrders] = useState<Record<number, Order>>({})
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const songData = await getMySongs()
+        setSongs(songData)
+        const orderData = await getOrders()
+        const map: Record<number, Order> = {}
+        orderData.forEach((o: Order) => {
+          map[o.id] = o
+        })
+        setOrders(map)
+      } catch (err) {
+        setError('Failed to load songs')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [])
+
+  if (loading) return <Container>Loading...</Container>
+  if (error) return <Container>{error}</Container>
+
+  return (
+    <Container>
+      <h2>Your Songs</h2>
+      {songs.length === 0 ? (
+        <p>No songs found.</p>
+      ) : (
+        <ul>
+          {songs.map((s) => (
+            <li key={s.id} style={{ marginBottom: '1rem' }}>
+              <p>Title: {s.title}</p>
+              <p>Status: {orders[s.order_id]?.status || 'unknown'}</p>
+              {orders[s.order_id]?.delivered_url && (
+                <a
+                  href={orders[s.order_id].delivered_url || ''}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Listen
+                </a>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </Container>
+  )
 }
 
 export default MySongs

--- a/frontend/src/services/songService.ts
+++ b/frontend/src/services/songService.ts
@@ -1,0 +1,11 @@
+import api from './api'
+
+export const getMySongs = async () => {
+  const response = await api.get('/songs/me')
+  return response.data
+}
+
+export const getSongByOrder = async (orderId: number) => {
+  const response = await api.get(`/songs/${orderId}`)
+  return response.data
+}

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -21,3 +21,13 @@ export interface Order {
   status: string
   delivered_url?: string | null
 }
+
+export interface Song {
+  id: number
+  order_id: number
+  title: string
+  genre: string
+  duration_seconds?: number | null
+  file_path: string
+  created_at: string
+}


### PR DESCRIPTION
## Summary
- add a `songService` to wrap song endpoints
- extend model types with a `Song` interface
- load user's songs on the **MySongs** page and show status and link

## Testing
- `pytest -q` *(fails: ModuleNotFoundError - sqlalchemy)*
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a4dafc644832da5653509db6cbcb9