### PR TITLE
Add profile API hooks and form

### DIFF
--- a/frontend/src/pages/Profile/Profile.tsx
+++ b/frontend/src/pages/Profile/Profile.tsx
@@ -1,8 +1,105 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { Container } from './styles'
+import {
+  FormGroup,
+  Input,
+  GradientButton,
+  Message,
+} from '../../styles/authFormStyles'
+import { getMe, updateMe, changePassword } from '../../services/authService'
+import { User } from '../../types/models'
 
 const Profile = () => {
-  return <Container>Profile Page</Container>
+  const [email, setEmail] = useState('')
+  const [username, setUsername] = useState('')
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [message, setMessage] = useState('')
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const data: User = await getMe()
+        setEmail(data.email)
+        setUsername(data.username)
+      } catch (err) {
+        setMessage('Failed to load profile')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchUser()
+  }, [])
+
+  const handleUpdate = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      await updateMe({ email, username })
+      setMessage('Profile updated')
+    } catch (err) {
+      setMessage('Update failed')
+    }
+  }
+
+  const handlePasswordChange = async (e: React.FormEvent) => {
+    e.preventDefault()
+    try {
+      await changePassword(currentPassword, newPassword)
+      setMessage('Password updated')
+      setCurrentPassword('')
+      setNewPassword('')
+    } catch (err) {
+      setMessage('Password change failed')
+    }
+  }
+
+  if (loading) return <Container>Loading...</Container>
+
+  return (
+    <Container>
+      <h2>Your Profile</h2>
+      <form onSubmit={handleUpdate} style={{ marginBottom: '2rem' }}>
+        <FormGroup>
+          <Input
+            placeholder="Email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+        </FormGroup>
+        <FormGroup>
+          <Input
+            placeholder="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+        </FormGroup>
+        <GradientButton type="submit">Update</GradientButton>
+      </form>
+
+      <form onSubmit={handlePasswordChange} style={{ marginBottom: '2rem' }}>
+        <FormGroup>
+          <Input
+            type="password"
+            placeholder="Current Password"
+            value={currentPassword}
+            onChange={(e) => setCurrentPassword(e.target.value)}
+          />
+        </FormGroup>
+        <FormGroup>
+          <Input
+            type="password"
+            placeholder="New Password"
+            value={newPassword}
+            onChange={(e) => setNewPassword(e.target.value)}
+          />
+        </FormGroup>
+        <GradientButton type="submit">Change Password</GradientButton>
+      </form>
+
+      {message && <Message>{message}</Message>}
+    </Container>
+  )
 }
 
 export default Profile

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -27,3 +27,30 @@ export const verifyAccount = async (token: string) => {
   const response = await api.post('/auth/verify', { token })
   return response.data
 }
+
+export const getMe = async () => {
+  const response = await api.get('/auth/me')
+  return response.data
+}
+
+export interface UpdateUserPayload {
+  email?: string
+  username?: string
+  password?: string
+}
+
+export const updateMe = async (payload: UpdateUserPayload) => {
+  const response = await api.put('/auth/me', payload)
+  return response.data
+}
+
+export const changePassword = async (
+  currentPassword: string,
+  newPassword: string,
+) => {
+  const response = await api.put('/auth/password', {
+    current_password: currentPassword,
+    new_password: newPassword,
+  })
+  return response.data
+}


### PR DESCRIPTION
## Summary
- add `getMe`, `updateMe`, `changePassword` to authService
- show profile information with update + password forms

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a561c3d54832d8485dbaccf75c414