### PR TITLE
Initialize auth context from stored token

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,16 +1,14 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuthContext } from '../../store/authContext'
-import { clearToken } from '../../utils/token'
 import { Container, Title, NavMenu, NavItem, LogoutButton } from './styles'
 
 const Header = () => {
   const navigate = useNavigate()
-  const { isAuthenticated, setIsAuthenticated } = useAuthContext()
+  const { isAuthenticated, logout } = useAuthContext()
 
   const handleLogout = () => {
-    clearToken()
-    setIsAuthenticated(false)
+    logout()
     navigate('/login')
   }
 

--- a/frontend/src/store/authContext.tsx
+++ b/frontend/src/store/authContext.tsx
@@ -1,17 +1,24 @@
 import React, { createContext, useContext, useState } from 'react'
+import { getToken, clearToken } from '../utils/token'
 
 type AuthContextType = {
   isAuthenticated: boolean
   setIsAuthenticated: (val: boolean) => void
+  logout: () => void
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const [isAuthenticated, setIsAuthenticated] = useState(false)
+  const [isAuthenticated, setIsAuthenticated] = useState(() => !!getToken())
+
+  const logout = () => {
+    clearToken()
+    setIsAuthenticated(false)
+  }
 
   return (
-    <AuthContext.Provider value={{ isAuthenticated, setIsAuthenticated }}>
+    <AuthContext.Provider value={{ isAuthenticated, setIsAuthenticated, logout }}>
       {children}
     </AuthContext.Provider>
   )


### PR DESCRIPTION
## Summary
- keep login state between refreshes by reading the saved token on context init
- add `logout()` helper to auth context
- update the header to use the new helper

## Testing
- `npm test` *(fails: react-scripts not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_688a58502b78832daa2c73e12e1e0259