### PR TITLE
Add frontend page tests

### DIFF
--- a/frontend/src/pages/Login/Login.test.tsx
+++ b/frontend/src/pages/Login/Login.test.tsx
@@ -1,0 +1,9 @@
+import Login from './Login';
+import { render, screen } from '../../testUtils';
+
+test('renders login form inputs', () => {
+  render(<Login />);
+  expect(screen.getByPlaceholderText(/email/i)).toBeInTheDocument();
+  expect(screen.getByPlaceholderText(/password/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /login/i })).toBeInTheDocument();
+});

--- a/frontend/src/pages/MySongs/MySongs.test.tsx
+++ b/frontend/src/pages/MySongs/MySongs.test.tsx
@@ -1,0 +1,44 @@
+import MySongs from './MySongs';
+import { render, screen, waitFor } from '../../testUtils';
+import * as songService from '../../services/songService';
+import * as orderService from '../../services/orderService';
+
+jest.mock('../../services/songService');
+jest.mock('../../services/orderService');
+
+describe('MySongs page', () => {
+  test('fetches and displays songs', async () => {
+    (songService.getMySongs as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        order_id: 10,
+        title: 'Song A',
+        genre: 'pop',
+        file_path: 'path',
+        created_at: '',
+      },
+    ]);
+    (orderService.getOrders as jest.Mock).mockResolvedValue([
+      {
+        id: 10,
+        song_package_id: 1,
+        recipient_name: 'x',
+        mood: 'y',
+        status: 'delivered',
+        delivered_url: 'http://example.com/file.mp3',
+      },
+    ]);
+
+    render(<MySongs />);
+
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    await waitFor(() => screen.getByText(/your songs/i));
+
+    expect(screen.getByText(/Title: Song A/i)).toBeInTheDocument();
+    expect(screen.getByText(/Status: delivered/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /listen/i })).toHaveAttribute(
+      'href',
+      'http://example.com/file.mp3',
+    );
+  });
+});

--- a/frontend/src/pages/Orders/Orders.test.tsx
+++ b/frontend/src/pages/Orders/Orders.test.tsx
@@ -1,0 +1,33 @@
+import Orders from './Orders';
+import { render, screen, waitFor } from '../../testUtils';
+import * as orderService from '../../services/orderService';
+import * as packageService from '../../services/songPackageService';
+
+jest.mock('../../services/orderService');
+jest.mock('../../services/songPackageService');
+
+describe('Orders page', () => {
+  test('fetches and displays orders', async () => {
+    (orderService.getOrders as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        song_package_id: 2,
+        recipient_name: 'John',
+        mood: 'happy',
+        status: 'pending',
+      },
+    ]);
+    (packageService.getSongPackages as jest.Mock).mockResolvedValue([
+      { id: 2, name: 'Gold', price_eur: 10, description: 'desc' },
+    ]);
+
+    render(<Orders />);
+
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    await waitFor(() => screen.getByText(/your orders/i));
+
+    expect(screen.getByText(/package: Gold/i)).toBeInTheDocument();
+    expect(screen.getByText(/Status: pending/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Register/Register.test.tsx
+++ b/frontend/src/pages/Register/Register.test.tsx
@@ -1,0 +1,10 @@
+import Register from './Register';
+import { render, screen } from '../../testUtils';
+
+test('renders register form inputs', () => {
+  render(<Register />);
+  expect(screen.getByPlaceholderText(/email/i)).toBeInTheDocument();
+  expect(screen.getByPlaceholderText(/username/i)).toBeInTheDocument();
+  expect(screen.getByPlaceholderText(/password/i)).toBeInTheDocument();
+  expect(screen.getByRole('button', { name: /register/i })).toBeInTheDocument();
+});

--- a/frontend/src/testUtils.tsx
+++ b/frontend/src/testUtils.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, RenderOptions } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
+import { lightTheme } from './theme';
+import { AuthProvider } from './store/authContext';
+
+const AllProviders: React.FC<{children: React.ReactNode}> = ({ children }) => (
+  <MemoryRouter>
+    <AuthProvider>
+      <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
+    </AuthProvider>
+  </MemoryRouter>
+);
+
+const customRender = (
+  ui: React.ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>,
+) => render(ui, { wrapper: AllProviders, ...options });
+
+export * from '@testing-library/react';
+export { customRender as render };


### PR DESCRIPTION
## Summary
- add a shared testUtils wrapper to simplify rendering with context
- test Login and Register pages render correctly
- mock API calls to test Orders and MySongs pages

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a59481344832da71f16748b0b76d7