### PR TITLE
Add CartProvider wrapper to frontend tests

### DIFF
--- a/frontend/src/testUtils.tsx
+++ b/frontend/src/testUtils.tsx
@@ -4,11 +4,14 @@ import { MemoryRouter } from 'react-router';
 import { ThemeProvider } from 'styled-components';
 import { lightTheme } from './theme';
 import { AuthProvider } from './store/authContext';
+import { CartProvider } from './store/cartContext';
 
 const AllProviders: React.FC<{children: React.ReactNode}> = ({ children }) => (
   <MemoryRouter>
     <AuthProvider>
-      <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
+      <CartProvider>
+        <ThemeProvider theme={lightTheme}>{children}</ThemeProvider>
+      </CartProvider>
     </AuthProvider>
   </MemoryRouter>
 );


### PR DESCRIPTION
## Summary
- wrap the test environment with CartProvider so pages using cart context don't error

## Testing
- `npm test -- -u` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a62fdf414832da52b89a788243af3