### PR TITLE
Fix tests to await async renders

### DIFF
--- a/frontend/src/pages/MySongs/MySongs.test.tsx
+++ b/frontend/src/pages/MySongs/MySongs.test.tsx
@@ -32,7 +32,7 @@ describe('MySongs page', () => {
     render(<MySongs />);
 
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
-    await waitFor(() => screen.getByText(/your songs/i));
+    await screen.findByText(/your songs/i);
 
     expect(screen.getByText(/Title: Song A/i)).toBeInTheDocument();
     expect(screen.getByText(/Status: delivered/i)).toBeInTheDocument();

--- a/frontend/src/pages/Orders/Orders.test.tsx
+++ b/frontend/src/pages/Orders/Orders.test.tsx
@@ -24,7 +24,7 @@ describe('Orders page', () => {
     render(<Orders />);
 
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
-    await waitFor(() => screen.getByText(/your orders/i));
+    await screen.findByText(/your orders/i);
 
     expect(screen.getByText(/package: Gold/i)).toBeInTheDocument();
     expect(screen.getByText(/Status: pending/i)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- ensure Orders and MySongs tests wait for async UI updates

## Testing
- `npm test -- -u --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a642497b4832da05b0985e767ac83