### PR TITLE
Refactor loading checks in Orders/MySongs tests

### DIFF
--- a/frontend/src/pages/MySongs/MySongs.test.tsx
+++ b/frontend/src/pages/MySongs/MySongs.test.tsx
@@ -31,8 +31,10 @@ describe('MySongs page', () => {
 
     render(<MySongs />);
 
-    expect(screen.getByText(/loading/i)).toBeInTheDocument();
     await screen.findByText(/your songs/i);
+    await waitFor(() =>
+      expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
+    );
 
     expect(screen.getByText(/Title: Song A/i)).toBeInTheDocument();
     expect(screen.getByText(/Status: delivered/i)).toBeInTheDocument();

--- a/frontend/src/pages/Orders/Orders.test.tsx
+++ b/frontend/src/pages/Orders/Orders.test.tsx
@@ -23,8 +23,10 @@ describe('Orders page', () => {
 
     render(<Orders />);
 
-    expect(screen.getByText(/loading/i)).toBeInTheDocument();
     await screen.findByText(/your orders/i);
+    await waitFor(() =>
+      expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
+    );
 
     expect(screen.getByText(/package: Gold/i)).toBeInTheDocument();
     expect(screen.getByText(/Status: pending/i)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- wait for page headings to appear before asserting other UI items
- verify the loading message disappears using `waitFor`

## Testing
- `npm --prefix frontend test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a6fa9dc6c832dac3ecb0a4e188f2d