### PR TITLE
Update router mocks for tests

### DIFF
--- a/frontend/src/setupTests.tsx
+++ b/frontend/src/setupTests.tsx
@@ -3,22 +3,18 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
-import { BrowserRouter } from "react-router";
 
 
 // The test environment does not install real browser routing or HTTP libraries.
 // Provide lightweight mocks so components depending on these packages can load.
 jest.mock('react-router', () => {
+  const actual = jest.requireActual('react-router-dom');
   const React = require('react');
   return {
-    MemoryRouter: ({ children }: { children: React.ReactNode }) => (
-      <div>{children}</div>
-    ),
-    BrowserRouter: ({ children }: { children: React.ReactNode }) => (
-      <div>{children}</div>
-    ),
-    Routes: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-    Route: ({ element }: { element: React.ReactNode }) => <>{element}</>,
+    ...actual,
+    MemoryRouter: actual.MemoryRouter,
+    Routes: actual.Routes,
+    Route: actual.Route,
     NavLink: ({ to, children }: { to: string; children: React.ReactNode }) => (
       <a href={to}>{children}</a>
     ),


### PR DESCRIPTION
## Summary
- use real `MemoryRouter`, `Routes` and `Route` components
- remove unused BrowserRouter import

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a71e468c8832d867193f533788e4c