### PR TITLE
Update react-router imports

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useNavigate } from 'react-router'
+import { useNavigate } from 'react-router-dom'
 import { useAuthContext } from '../../store/authContext'
 import { Container, Title, NavMenu, NavItem, LogoutButton } from './styles'
 

--- a/frontend/src/components/Header/styles.ts
+++ b/frontend/src/components/Header/styles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { NavLink } from 'react-router'
+import { NavLink } from 'react-router-dom'
 
 export const Container = styled.header`
   padding: 1rem;

--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useNavigate } from 'react-router'
+import { useNavigate } from 'react-router-dom'
 import {
   HeroSection,
   HeroTitle,

--- a/frontend/src/pages/Login/Login.tsx
+++ b/frontend/src/pages/Login/Login.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { useNavigate } from 'react-router'
+import { useNavigate } from 'react-router-dom'
 import {
   AuthContainer,
   AuthCard,

--- a/frontend/src/pages/PackageDetail/PackageDetail.tsx
+++ b/frontend/src/pages/PackageDetail/PackageDetail.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router'
+import { useNavigate, useParams } from 'react-router-dom'
 import { Overlay, Modal, ActionButton } from './styles'
 import { getSongPackage } from '../../services/songPackageService'
 import { SongPackage } from '../../types/models'

--- a/frontend/src/pages/SongForm/SongForm.tsx
+++ b/frontend/src/pages/SongForm/SongForm.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useNavigate, useParams } from 'react-router'
+import { useNavigate, useParams } from 'react-router-dom'
 import {
   Overlay,
   Modal,

--- a/frontend/src/pages/SongPackages/SongPackages.tsx
+++ b/frontend/src/pages/SongPackages/SongPackages.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router'
+import { useNavigate } from 'react-router-dom'
 import { Overlay, Modal, PackagesGrid, PackageCard } from './styles'
 import { getSongPackages } from '../../services/songPackageService'
 import { SongPackage } from '../../types/models'

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Routes, Route } from 'react-router'
+import { Routes, Route } from 'react-router-dom'
 import Home from '../pages/Home'
 import Login from '../pages/Login'
 import Register from '../pages/Register'

--- a/frontend/src/setupTests.tsx
+++ b/frontend/src/setupTests.tsx
@@ -7,14 +7,11 @@ import '@testing-library/jest-dom';
 
 // The test environment does not install real browser routing or HTTP libraries.
 // Provide lightweight mocks so components depending on these packages can load.
-jest.mock('react-router', () => {
+jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom');
   const React = require('react');
   return {
     ...actual,
-    MemoryRouter: actual.MemoryRouter,
-    Routes: actual.Routes,
-    Route: actual.Route,
     NavLink: ({ to, children }: { to: string; children: React.ReactNode }) => (
       <a href={to}>{children}</a>
     ),

--- a/frontend/src/testUtils.tsx
+++ b/frontend/src/testUtils.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, RenderOptions } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 import { lightTheme } from './theme';
 import { AuthProvider } from './store/authContext';


### PR DESCRIPTION
## Summary
- update react-router imports to react-router-dom
- adjust router mock in tests

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a7631e650832d8bb8111d3bf349dd