### PR TITLE
Add admin UI pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ npm test
 
 Both commands should execute the respective test suites (`pytest` for Python and `npm test` for React).
 
+## Admin Interface
+
+If you log in as a user with `is_admin` set to `true`, the navigation now exposes links to view all orders and upload finished songs.  The new pages are available at `/admin/orders` and `/admin/upload`.
+
 ## Email Configuration
 
 Account verification and password reset emails are sent using SMTP. Configure the

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -5,7 +5,7 @@ import { Container, Title, NavMenu, NavItem, LogoutButton } from './styles'
 
 const Header = () => {
   const navigate = useNavigate()
-  const { isAuthenticated, logout } = useAuthContext()
+  const { isAuthenticated, isAdmin, logout } = useAuthContext()
 
   const handleLogout = () => {
     logout()
@@ -22,6 +22,7 @@ const Header = () => {
         <NavItem to="/packages">Package</NavItem>
         {isAuthenticated ? (
           <>
+            {isAdmin && <NavItem to="/admin/orders">Admin</NavItem>}
             <NavItem to="/orders">Orders</NavItem>
             <NavItem to="/mysongs">My Songs</NavItem>
             <LogoutButton onClick={handleLogout}>Logout</LogoutButton>

--- a/frontend/src/pages/AdminOrders/AdminOrders.test.tsx
+++ b/frontend/src/pages/AdminOrders/AdminOrders.test.tsx
@@ -1,0 +1,33 @@
+import AdminOrders from './AdminOrders'
+import { render, screen, waitFor } from '../../testUtils'
+import * as adminService from '../../services/adminService'
+
+jest.mock('../../services/adminService')
+
+describe('AdminOrders page', () => {
+  test('fetches and displays admin orders', async () => {
+    ;(adminService.getAllOrders as jest.Mock).mockResolvedValue([
+      {
+        id: 1,
+        recipient_name: 'Rec',
+        mood: 'happy',
+        facts: null,
+        status: 'pending',
+        delivered_url: null,
+        created_at: '2024-01-01',
+        user: { id: 1, email: 'admin@test.com' },
+        package: { id: 2, name: 'Gold' },
+      },
+    ])
+
+    render(<AdminOrders />)
+
+    await screen.findByText(/all orders/i)
+    await waitFor(() =>
+      expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
+    )
+
+    expect(screen.getByText(/admin@test.com/i)).toBeInTheDocument()
+    expect(screen.getByText(/Status: pending/i)).toBeInTheDocument()
+  })
+})

--- a/frontend/src/pages/AdminOrders/AdminOrders.tsx
+++ b/frontend/src/pages/AdminOrders/AdminOrders.tsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react'
+import { Container } from './styles'
+import { getAllOrders } from '../../services/adminService'
+import { AdminOrder } from '../../types/models'
+
+const AdminOrders = () => {
+  const [orders, setOrders] = useState<AdminOrder[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await getAllOrders()
+        setOrders(data)
+      } catch (err) {
+        setError('Failed to load orders')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [])
+
+  if (loading) return <Container>Loading...</Container>
+  if (error) return <Container>{error}</Container>
+
+  return (
+    <Container>
+      <h2>All Orders</h2>
+      {orders.length === 0 ? (
+        <p>No orders found.</p>
+      ) : (
+        <ul>
+          {orders.map((o) => (
+            <li key={o.id} style={{ marginBottom: '1rem' }}>
+              <p>User: {o.user.email}</p>
+              <p>Package: {o.package.name}</p>
+              <p>Status: {o.status}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Container>
+  )
+}
+
+export default AdminOrders

--- a/frontend/src/pages/AdminOrders/index.ts
+++ b/frontend/src/pages/AdminOrders/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AdminOrders'

--- a/frontend/src/pages/AdminOrders/styles.ts
+++ b/frontend/src/pages/AdminOrders/styles.ts
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+
+export const Container = styled.div`
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 1rem;
+  font-size: 1.2rem;
+  text-align: center;
+`

--- a/frontend/src/pages/AdminUpload/AdminUpload.tsx
+++ b/frontend/src/pages/AdminUpload/AdminUpload.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react'
+import { Container } from './styles'
+import { uploadSong } from '../../services/adminService'
+
+const AdminUpload = () => {
+  const [orderId, setOrderId] = useState('')
+  const [title, setTitle] = useState('')
+  const [genre, setGenre] = useState('')
+  const [duration, setDuration] = useState('')
+  const [file, setFile] = useState<File | null>(null)
+  const [message, setMessage] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!file) return
+    try {
+      await uploadSong({
+        order_id: Number(orderId),
+        title,
+        genre,
+        duration_seconds: Number(duration),
+        file,
+      })
+      setMessage('Song uploaded')
+    } catch (err) {
+      setMessage('Upload failed')
+    }
+  }
+
+  return (
+    <Container>
+      <h2>Upload Song</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          placeholder="Order ID"
+          value={orderId}
+          onChange={(e) => setOrderId(e.target.value)}
+        />
+        <input
+          placeholder="Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+        <input
+          placeholder="Genre"
+          value={genre}
+          onChange={(e) => setGenre(e.target.value)}
+        />
+        <input
+          placeholder="Duration seconds"
+          value={duration}
+          onChange={(e) => setDuration(e.target.value)}
+        />
+        <input type="file" onChange={(e) => setFile(e.target.files?.[0] || null)} />
+        <button type="submit">Upload</button>
+      </form>
+      {message && <p>{message}</p>}
+    </Container>
+  )
+}
+
+export default AdminUpload

--- a/frontend/src/pages/AdminUpload/index.ts
+++ b/frontend/src/pages/AdminUpload/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AdminUpload'

--- a/frontend/src/pages/AdminUpload/styles.ts
+++ b/frontend/src/pages/AdminUpload/styles.ts
@@ -1,0 +1,16 @@
+import styled from 'styled-components'
+
+export const Container = styled.div`
+  max-width: 800px;
+  margin: 2rem auto;
+  padding: 1rem;
+  font-size: 1.2rem;
+  text-align: center;
+
+  form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+`

--- a/frontend/src/pages/Login/Login.tsx
+++ b/frontend/src/pages/Login/Login.tsx
@@ -8,7 +8,7 @@ import {
   GradientButton,
   Message,
 } from '../../styles/authFormStyles'
-import { login } from '../../services/authService'
+import { login, getMe } from '../../services/authService'
 import { saveToken } from '../../utils/token'
 import { useAuthContext } from '../../store/authContext'
 
@@ -17,14 +17,16 @@ const Login = () => {
   const [password, setPassword] = useState('')
   const [message, setMessage] = useState('')
   const navigate = useNavigate()
-  const { setIsAuthenticated } = useAuthContext()
+  const { setIsAuthenticated, setIsAdmin } = useAuthContext()
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     try {
       const data = await login(email, password)
       saveToken(data.access_token)
+      const me = await getMe()
       setIsAuthenticated(true)
+      setIsAdmin(me.is_admin)
       navigate('/')
     } catch (err) {
       setMessage('Login failed')

--- a/frontend/src/routes/AppRoutes.tsx
+++ b/frontend/src/routes/AppRoutes.tsx
@@ -11,6 +11,8 @@ import Cart from '../pages/Cart'
 import Profile from '../pages/Profile'
 import About from '../pages/About'
 import MySongs from '../pages/MySongs'
+import AdminOrders from '../pages/AdminOrders'
+import AdminUpload from '../pages/AdminUpload'
 
 const AppRoutes = () => {
   return (
@@ -26,6 +28,8 @@ const AppRoutes = () => {
       <Route path="/profile" element={<Profile />} />
       <Route path="/about" element={<About />} />
       <Route path="/mysongs" element={<MySongs />} />
+      <Route path="/admin/orders" element={<AdminOrders />} />
+      <Route path="/admin/upload" element={<AdminUpload />} />
     </Routes>
   )
 }

--- a/frontend/src/services/adminService.ts
+++ b/frontend/src/services/adminService.ts
@@ -1,0 +1,27 @@
+import api from './api'
+
+export const getAllOrders = async () => {
+  const response = await api.get('/admin/orders/')
+  return response.data
+}
+
+export interface UploadSongPayload {
+  order_id: number
+  title: string
+  genre: string
+  duration_seconds: number
+  file: File
+}
+
+export const uploadSong = async (payload: UploadSongPayload) => {
+  const data = new FormData()
+  data.append('order_id', String(payload.order_id))
+  data.append('title', payload.title)
+  data.append('genre', payload.genre)
+  data.append('duration_seconds', String(payload.duration_seconds))
+  data.append('file', payload.file)
+  const response = await api.post('/admin/songs/', data, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  })
+  return response.data
+}

--- a/frontend/src/store/authContext.tsx
+++ b/frontend/src/store/authContext.tsx
@@ -4,6 +4,8 @@ import { getToken, clearToken } from '../utils/token'
 type AuthContextType = {
   isAuthenticated: boolean
   setIsAuthenticated: (val: boolean) => void
+  isAdmin: boolean
+  setIsAdmin: (val: boolean) => void
   logout: () => void
 }
 
@@ -11,14 +13,16 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined)
 
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [isAuthenticated, setIsAuthenticated] = useState(() => !!getToken())
+  const [isAdmin, setIsAdmin] = useState(false)
 
   const logout = () => {
     clearToken()
     setIsAuthenticated(false)
+    setIsAdmin(false)
   }
 
   return (
-    <AuthContext.Provider value={{ isAuthenticated, setIsAuthenticated, logout }}>
+    <AuthContext.Provider value={{ isAuthenticated, setIsAuthenticated, isAdmin, setIsAdmin, logout }}>
       {children}
     </AuthContext.Provider>
   )

--- a/frontend/src/types/models.ts
+++ b/frontend/src/types/models.ts
@@ -3,6 +3,7 @@ export interface User {
   email: string
   username: string
   isVerified: boolean
+  is_admin?: boolean
 }
 
 export interface SongPackage {
@@ -30,4 +31,22 @@ export interface Song {
   duration_seconds?: number | null
   file_path: string
   created_at: string
+}
+
+export interface AdminOrder {
+  id: number
+  recipient_name: string
+  mood: string | null
+  facts: string | null
+  status: string
+  delivered_url?: string | null
+  created_at: string
+  user: {
+    id: number
+    email: string
+  }
+  package: {
+    id: number
+    name: string
+  }
 }


### PR DESCRIPTION
## Summary
- extend auth context to store admin status
- fetch user info on login and show admin links in header
- add admin pages to list all orders and upload completed songs
- create admin API helpers and TypeScript models
- document new admin interface in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent -- --runTestsByPath src/pages/AdminOrders/AdminOrders.test.tsx` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a781dd604832da56293c5ebb109a8