### PR TITLE
Display order id on admin orders page

### DIFF
--- a/frontend/src/pages/AdminOrders/AdminOrders.test.tsx
+++ b/frontend/src/pages/AdminOrders/AdminOrders.test.tsx
@@ -27,6 +27,7 @@ describe('AdminOrders page', () => {
       expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
     )
 
+    expect(screen.getByText(/Order ID: 1/)).toBeInTheDocument()
     expect(screen.getByText(/admin@test.com/i)).toBeInTheDocument()
     expect(screen.getByText(/Status: pending/i)).toBeInTheDocument()
   })

--- a/frontend/src/pages/AdminOrders/AdminOrders.tsx
+++ b/frontend/src/pages/AdminOrders/AdminOrders.tsx
@@ -32,8 +32,9 @@ const AdminOrders = () => {
         <p>No orders found.</p>
       ) : (
         <ul>
-          {orders.map((o) => (
+            {orders.map((o) => (
             <li key={o.id} style={{ marginBottom: '1rem' }}>
+              <p>Order ID: {o.id}</p>
               <p>User: {o.user.email}</p>
               <p>Package: {o.package.name}</p>
               <p>Status: {o.status}</p>


### PR DESCRIPTION
## Summary
- show Order ID on each order in the admin orders list
- update tests to expect the Order ID text

## Testing
- `pytest --maxfail=1 -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `cd frontend && npm test -- -u --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a7c267990832d9436d8df2031ab71