### PR TITLE
Add audio playback and download buttons for delivered songs

### DIFF
--- a/frontend/src/pages/MySongs/MySongs.test.tsx
+++ b/frontend/src/pages/MySongs/MySongs.test.tsx
@@ -38,9 +38,14 @@ describe('MySongs page', () => {
 
     expect(screen.getByText(/Title: Song A/i)).toBeInTheDocument();
     expect(screen.getByText(/Status: delivered/i)).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /listen/i })).toHaveAttribute(
+    expect(screen.getByTestId('audio-player')).toHaveAttribute(
+      'src',
+      'http://example.com/file.mp3',
+    );
+    expect(screen.getByTestId('download-link')).toHaveAttribute(
       'href',
       'http://example.com/file.mp3',
     );
+    expect(screen.getByTestId('download-link')).toHaveAttribute('download');
   });
 });

--- a/frontend/src/pages/MySongs/MySongs.tsx
+++ b/frontend/src/pages/MySongs/MySongs.tsx
@@ -45,13 +45,20 @@ const MySongs = () => {
               <p>Title: {s.title}</p>
               <p>Status: {orders[s.order_id]?.status || 'unknown'}</p>
               {orders[s.order_id]?.delivered_url && (
-                <a
-                  href={orders[s.order_id].delivered_url || ''}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Listen
-                </a>
+                <div>
+                  <audio
+                    data-testid="audio-player"
+                    controls
+                    src={orders[s.order_id].delivered_url || ''}
+                  />
+                  <a
+                    data-testid="download-link"
+                    href={orders[s.order_id].delivered_url || ''}
+                    download
+                  >
+                    Download
+                  </a>
+                </div>
               )}
             </li>
           ))}

--- a/frontend/src/pages/Orders/Orders.test.tsx
+++ b/frontend/src/pages/Orders/Orders.test.tsx
@@ -16,6 +16,14 @@ describe('Orders page', () => {
         mood: 'happy',
         status: 'pending',
       },
+      {
+        id: 2,
+        song_package_id: 2,
+        recipient_name: 'Jane',
+        mood: 'sad',
+        status: 'delivered',
+        delivered_url: 'http://example.com/file.mp3',
+      },
     ]);
     (packageService.getSongPackages as jest.Mock).mockResolvedValue([
       { id: 2, name: 'Gold', price_eur: 10, description: 'desc' },
@@ -28,8 +36,18 @@ describe('Orders page', () => {
       expect(screen.queryByText(/loading/i)).not.toBeInTheDocument(),
     );
 
-    expect(screen.getByText(/package: Gold/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/package: Gold/i)).toHaveLength(2);
     expect(screen.getByText(/Status: pending/i)).toBeInTheDocument();
+    expect(screen.getByText(/Status: delivered/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    expect(screen.getByTestId('audio-player')).toHaveAttribute(
+      'src',
+      'http://example.com/file.mp3',
+    );
+    expect(screen.getByTestId('download-link')).toHaveAttribute(
+      'href',
+      'http://example.com/file.mp3',
+    );
+    expect(screen.getByTestId('download-link')).toHaveAttribute('download');
   });
 });

--- a/frontend/src/pages/Orders/Orders.tsx
+++ b/frontend/src/pages/Orders/Orders.tsx
@@ -57,17 +57,33 @@ const Orders = () => {
       ) : (
         <ul>
           {orders.map((o) => (
-            <li key={o.id} style={{ marginBottom: '1rem' }}>
-              <p>
-                Package:{' '}
-                {packages[o.song_package_id]?.name || o.song_package_id}
-              </p>
-              <p>Status: {o.status}</p>
-              {o.status === 'pending' && (
-                <button onClick={() => handleCancel(o.id)}>Cancel</button>
-              )}
-            </li>
-          ))}
+              <li key={o.id} style={{ marginBottom: '1rem' }}>
+                <p>
+                  Package:{' '}
+                  {packages[o.song_package_id]?.name || o.song_package_id}
+                </p>
+                <p>Status: {o.status}</p>
+                {o.status === 'pending' && (
+                  <button onClick={() => handleCancel(o.id)}>Cancel</button>
+                )}
+                {o.delivered_url && (
+                  <div>
+                    <audio
+                      data-testid="audio-player"
+                      controls
+                      src={o.delivered_url}
+                    />
+                    <a
+                      data-testid="download-link"
+                      href={o.delivered_url}
+                      download
+                    >
+                      Download
+                    </a>
+                  </div>
+                )}
+              </li>
+            ))}
         </ul>
       )}
     </Container>


### PR DESCRIPTION
## Summary
- enhance `MySongs` page with inline audio player and download link for delivered songs
- show same controls on each delivered order
- update tests for new audio and download features

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a7d6faae4832db42c63a6643e54ae