### PR TITLE
Ensure media directory exists for admin uploads

### DIFF
--- a/backend/app/routes/admin_songs.py
+++ b/backend/app/routes/admin_songs.py
@@ -53,6 +53,9 @@ async def upload_song(
     file_location = os.path.join("media", "songs", filename)
 
     try:
+        # Ensure the destination directory exists so file writes don't fail
+        os.makedirs(os.path.dirname(file_location), exist_ok=True)
+
         with open(file_location, "wb") as buffer:
             shutil.copyfileobj(file.file, buffer)
 


### PR DESCRIPTION
## Summary
- ensure the `media/songs` directory exists when uploading via `/admin/songs/`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a7f12a824832da05b10659537e86d