### PR TITLE
Ensure media path uses backend base

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,8 @@ from fastapi.staticfiles import StaticFiles
 from app.routes import admin_songs
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from pathlib import Path
+from .db import BASE_DIR
 
 
 
@@ -52,8 +54,11 @@ app.include_router(admin_songs.router)
 
 
 # Serve uploaded song files from /media/
+# Resolve the directory relative to the backend base so the app works
+# regardless of the current working directory.
+media_dir = BASE_DIR / "media"
 # Allow the directory to be missing during startup (tests may create it later)
-app.mount("/media", StaticFiles(directory="media", check_dir=False), name="media")
+app.mount("/media", StaticFiles(directory=str(media_dir), check_dir=False), name="media")
 
 
 

--- a/backend/app/routes/admin_songs.py
+++ b/backend/app/routes/admin_songs.py
@@ -4,7 +4,7 @@ import os
 from uuid import uuid4
 import shutil
 
-from app.db import get_db
+from app.db import get_db, BASE_DIR
 from app.models.song import Song
 from app.models.order import Order
 from app.schemas.song import SongUploadResponse
@@ -50,9 +50,12 @@ async def upload_song(
 
     # 5. Save file to disk
     filename = f"song_{order_id}_{uuid4().hex}.mp3"
-    file_location = os.path.join("media", "songs", filename)
+    file_location = BASE_DIR / "media" / "songs" / filename
 
     try:
+        # Ensure the destination directory exists so file writes don't fail
+        os.makedirs(file_location.parent, exist_ok=True)
+
         with open(file_location, "wb") as buffer:
             shutil.copyfileobj(file.file, buffer)
 
@@ -62,7 +65,7 @@ async def upload_song(
             title=title,
             genre=genre,
             duration_seconds=duration_seconds,
-            file_path=file_location,
+            file_path=str(file_location),
         )
         db.add(song)
 


### PR DESCRIPTION
## Summary
- serve media files from an absolute path based on `BASE_DIR`
- save uploaded files using the same absolute media directory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a7f12a824832da05b10659537e86d