### PR TITLE
Document frontend port and update start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ cd frontend
 npm install
 ```
 
+The development server runs on port `8001`. Start it with:
+
+```bash
+npm start
+```
+and open [http://localhost:8001](http://localhost:8001) in your browser.
+
 ## Running Tests
 
 ### Backend tests

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,7 +9,7 @@ In the project directory, you can run:
 ### `npm start`
 
 Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in the browser.
+Open [http://localhost:8001](http://localhost:8001) to view it in the browser.
 
 The page will reload if you make edits.\
 You will also see any lint errors in the console.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "PORT=8001 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject"


### PR DESCRIPTION
## Summary
- run the CRA dev server on port 8001
- explain how to start the frontend dev server in the README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a86d611c8832dafe618b3dd90a8a6