### PR TITLE
Add BASE_URL and update delivered_url

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -6,6 +6,8 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
     REFRESH_TOKEN_EXPIRE_DAYS: int = 7
 
+    BASE_URL: str = "http://localhost:8000"
+
     SMTP_HOST: str | None = None
     SMTP_PORT: int = 587
     SMTP_USER: str | None = None

--- a/backend/app/routes/admin_songs.py
+++ b/backend/app/routes/admin_songs.py
@@ -10,6 +10,7 @@ from app.models.order import Order
 from app.schemas.song import SongUploadResponse
 from app.dependencies.auth import is_admin
 from app.models.user import User
+from app.core.config import settings
 
 router = APIRouter(prefix="/admin/songs", tags=["admin:songs"])
 
@@ -71,7 +72,7 @@ async def upload_song(
 
         # 7. Mark order as delivered and store url
         order.status = "delivered"
-        order.delivered_url = f"/media/songs/{filename}"
+        order.delivered_url = f"{settings.BASE_URL}/media/songs/{filename}"
 
         db.commit()
         db.refresh(song)

--- a/backend/tests/test_admin_songs.py
+++ b/backend/tests/test_admin_songs.py
@@ -43,7 +43,7 @@ def test_upload_song_success(client):
     assert orders.status_code == status.HTTP_200_OK
     admin_order = orders.json()[0]
     assert admin_order["status"] == "delivered"
-    assert admin_order["delivered_url"].startswith("/media/songs/")
+    assert admin_order["delivered_url"].startswith("http://localhost:8000/media/songs/")
 
 
 def test_upload_song_invalid_file_type(client):


### PR DESCRIPTION
## Summary
- include BASE_URL option in Settings
- use BASE_URL when saving admin order's delivered URL
- update expectation in admin songs test

## Testing
- `pytest -q backend/tests` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_688a8a2aa804832dbed3e91888f7b112