### PR TITLE
Prefix delivered URLs with backend base

### DIFF
--- a/frontend/src/pages/MySongs/MySongs.test.tsx
+++ b/frontend/src/pages/MySongs/MySongs.test.tsx
@@ -2,6 +2,7 @@ import MySongs from './MySongs';
 import { render, screen, waitFor } from '../../testUtils';
 import * as songService from '../../services/songService';
 import * as orderService from '../../services/orderService';
+import { BACKEND_BASE_URL } from '../../services/api';
 
 jest.mock('../../services/songService');
 jest.mock('../../services/orderService');
@@ -25,7 +26,7 @@ describe('MySongs page', () => {
         recipient_name: 'x',
         mood: 'y',
         status: 'delivered',
-        delivered_url: 'http://example.com/file.mp3',
+        delivered_url: '/file.mp3',
       },
     ]);
 
@@ -40,11 +41,11 @@ describe('MySongs page', () => {
     expect(screen.getByText(/Status: delivered/i)).toBeInTheDocument();
     expect(screen.getByTestId('audio-player')).toHaveAttribute(
       'src',
-      'http://example.com/file.mp3',
+      `${BACKEND_BASE_URL}/file.mp3`,
     );
     expect(screen.getByTestId('download-link')).toHaveAttribute(
       'href',
-      'http://example.com/file.mp3',
+      `${BACKEND_BASE_URL}/file.mp3`,
     );
     expect(screen.getByTestId('download-link')).toHaveAttribute('download');
   });

--- a/frontend/src/pages/MySongs/MySongs.tsx
+++ b/frontend/src/pages/MySongs/MySongs.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { Container } from './styles'
 import { getMySongs } from '../../services/songService'
 import { getOrders } from '../../services/orderService'
+import { BACKEND_BASE_URL } from '../../services/api'
 import { Song, Order } from '../../types/models'
 
 const MySongs = () => {
@@ -49,11 +50,11 @@ const MySongs = () => {
                   <audio
                     data-testid="audio-player"
                     controls
-                    src={orders[s.order_id].delivered_url || ''}
+                    src={`${BACKEND_BASE_URL}${orders[s.order_id].delivered_url || ''}`}
                   />
                   <a
                     data-testid="download-link"
-                    href={orders[s.order_id].delivered_url || ''}
+                    href={`${BACKEND_BASE_URL}${orders[s.order_id].delivered_url || ''}`}
                     download
                   >
                     Download

--- a/frontend/src/pages/Orders/Orders.test.tsx
+++ b/frontend/src/pages/Orders/Orders.test.tsx
@@ -2,6 +2,7 @@ import Orders from './Orders';
 import { render, screen, waitFor } from '../../testUtils';
 import * as orderService from '../../services/orderService';
 import * as packageService from '../../services/songPackageService';
+import { BACKEND_BASE_URL } from '../../services/api';
 
 jest.mock('../../services/orderService');
 jest.mock('../../services/songPackageService');
@@ -22,7 +23,7 @@ describe('Orders page', () => {
         recipient_name: 'Jane',
         mood: 'sad',
         status: 'delivered',
-        delivered_url: 'http://example.com/file.mp3',
+        delivered_url: '/file.mp3',
       },
     ]);
     (packageService.getSongPackages as jest.Mock).mockResolvedValue([
@@ -42,11 +43,11 @@ describe('Orders page', () => {
     expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
     expect(screen.getByTestId('audio-player')).toHaveAttribute(
       'src',
-      'http://example.com/file.mp3',
+      `${BACKEND_BASE_URL}/file.mp3`,
     );
     expect(screen.getByTestId('download-link')).toHaveAttribute(
       'href',
-      'http://example.com/file.mp3',
+      `${BACKEND_BASE_URL}/file.mp3`,
     );
     expect(screen.getByTestId('download-link')).toHaveAttribute('download');
   });

--- a/frontend/src/pages/Orders/Orders.tsx
+++ b/frontend/src/pages/Orders/Orders.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { Container } from './styles'
 import { getOrders, cancelOrder } from '../../services/orderService'
 import { getSongPackages } from '../../services/songPackageService'
+import { BACKEND_BASE_URL } from '../../services/api'
 import { Order, SongPackage } from '../../types/models'
 
 const Orders = () => {
@@ -71,11 +72,11 @@ const Orders = () => {
                     <audio
                       data-testid="audio-player"
                       controls
-                      src={o.delivered_url}
+                      src={`${BACKEND_BASE_URL}${o.delivered_url}`}
                     />
                     <a
                       data-testid="download-link"
-                      href={o.delivered_url}
+                      href={`${BACKEND_BASE_URL}${o.delivered_url}`}
                       download
                     >
                       Download

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,8 +1,10 @@
 import axios from 'axios'
 import { getToken } from '../utils/token'
 
+export const BACKEND_BASE_URL = 'http://localhost:8000'
+
 const api = axios.create({
-  baseURL: 'http://localhost:8000',
+  baseURL: BACKEND_BASE_URL,
 })
 
 api.interceptors.request.use((config) => {


### PR DESCRIPTION
## Summary
- export `BACKEND_BASE_URL` from api service
- use the base URL when rendering delivered song links
- adjust unit tests for new path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a8b265f44832d8a806644a750542f