### PR TITLE
Adjust delivered_url path in admin songs

### DIFF
--- a/backend/app/routes/admin_songs.py
+++ b/backend/app/routes/admin_songs.py
@@ -72,7 +72,7 @@ async def upload_song(
 
         # 7. Mark order as delivered and store url
         order.status = "delivered"
-        order.delivered_url = f"{settings.BASE_URL}/media/songs/{filename}"
+        order.delivered_url = f"/media/songs/{filename}"
 
         db.commit()
         db.refresh(song)

--- a/backend/tests/test_admin_songs.py
+++ b/backend/tests/test_admin_songs.py
@@ -43,7 +43,7 @@ def test_upload_song_success(client):
     assert orders.status_code == status.HTTP_200_OK
     admin_order = orders.json()[0]
     assert admin_order["status"] == "delivered"
-    assert admin_order["delivered_url"].startswith("http://localhost:8000/media/songs/")
+    assert admin_order["delivered_url"].startswith("/media/songs/")
 
 
 def test_upload_song_invalid_file_type(client):


### PR DESCRIPTION
## Summary
- change delivered_url to store relative URL only
- update tests to match new path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a90215cfc832d8e377bb3a8611a27