### PR TITLE
Send verification email on signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Both commands should execute the respective test suites (`pytest` for Python and
 
 If you log in as a user with `is_admin` set to `true`, the navigation now exposes links to view all orders and upload finished songs.  The new pages are available at `/admin/orders` and `/admin/upload`.
 
+When a user registers for an account, the backend immediately emails a verification link to the provided address.
+
 ## Email Configuration
 
 Account verification and password reset emails are sent using SMTP. Configure the

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -56,6 +56,12 @@ def register(
     db.add(new_user)
     db.commit()
     db.refresh(new_user)
+    verify_url = f"{settings.BASE_URL}/verify?token={new_user.verification_token}"
+    send_email(
+        to=new_user.email,
+        subject="Verify your account",
+        body=f"Click the link to verify your account: {verify_url}",
+    )
     return new_user
 
 

--- a/frontend/src/pages/Register/Register.tsx
+++ b/frontend/src/pages/Register/Register.tsx
@@ -7,11 +7,7 @@ import {
   GradientButton,
   Message,
 } from '../../styles/authFormStyles'
-import {
-  register,
-  requestVerification,
-  verifyAccount,
-} from '../../services/authService'
+import { register, verifyAccount } from '../../services/authService'
 
 const Register = () => {
   const [email, setEmail] = useState('')
@@ -26,9 +22,8 @@ const Register = () => {
     e.preventDefault()
     try {
       await register(email, username, password)
-      const res = await requestVerification(email)
       setRegistered(true)
-      setMessage(`Verification token: ${res.token}`)
+      setMessage('Check your email for a verification link')
     } catch (err) {
       setMessage('Registration failed')
     }


### PR DESCRIPTION
## Summary
- send verification email directly after registering a user
- adjust register page to reflect email being sent
- document automatic verification emails in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_688a95d7a770832d9fe3ce52b1838462