### PR TITLE
Fix children prop types

### DIFF
--- a/frontend/src/routes/AdminRoute.tsx
+++ b/frontend/src/routes/AdminRoute.tsx
@@ -3,7 +3,7 @@ import { Navigate } from 'react-router-dom'
 import { useAuthContext } from '../store/authContext'
 
 interface Props {
-  children: JSX.Element
+  children: React.ReactNode
 }
 
 const AdminRoute: React.FC<Props> = ({ children }) => {

--- a/frontend/src/routes/ProtectedRoute.tsx
+++ b/frontend/src/routes/ProtectedRoute.tsx
@@ -3,7 +3,7 @@ import { Navigate } from 'react-router-dom'
 import { useAuthContext } from '../store/authContext'
 
 interface Props {
-  children: JSX.Element
+  children: React.ReactNode
 }
 
 const AdminRoute: React.FC<Props> = ({ children }) => {


### PR DESCRIPTION
## Summary
- update children type definitions for protected/admin routes

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_688bc34c76cc832d896b2f9d89fcc8b5