### PR TITLE
Make CORS origins configurable via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,7 @@ The API now uses Redis to store rate limiting counters. Set the `REDIS_URL`
 environment variable to point to your Redis instance (defaults to
 `redis://localhost:6379/0`). Ensure Redis is running before starting the
 backend server.
+
+The allowed CORS origins are also configurable. Set `ALLOWED_ORIGINS` to a
+comma-separated list of origins (or `*` to allow any origin) when launching the
+backend.

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -15,6 +15,7 @@ class Settings(BaseSettings):
     SMTP_USER: str | None = None
     SMTP_PASSWORD: str | None = None
     EMAIL_FROM: str = "no-reply@example.com"
+    ALLOWED_ORIGINS: str = "*"
 
     model_config = SettingsConfigDict(env_file=".env")
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from app.routes import admin_songs
 from fastapi.responses import FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 from .db import BASE_DIR
+from app.core.config import settings
 
 
 
@@ -24,9 +25,13 @@ app = FastAPI()
 # ✅ Create tables
 Base.metadata.create_all(bind=engine)
 
+origins = ["*"]
+if settings.ALLOWED_ORIGINS != "*":
+    origins = [o.strip() for o in settings.ALLOWED_ORIGINS.split(",") if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- configure CORSMiddleware using `ALLOWED_ORIGINS` setting
- expose new `ALLOWED_ORIGINS` option in settings
- document allowed CORS origins in README

## Testing
- `pytest -q` *(fails: ConnectionError to redis)*

------
https://chatgpt.com/codex/tasks/task_e_688ca372b38c832d9dc258c983ea6d59